### PR TITLE
Adding AI/ML/DL/DS competition site links

### DIFF
--- a/Competitions-coding-challenges.md
+++ b/Competitions-coding-challenges.md
@@ -1,5 +1,0 @@
-# Competitions / coding challenges
-
-- [Hacker Rank](https://lnkd.in/gEufBUu)
-- [Codeacademy](https://lnkd.in/gGQ7cuv)
-- [LeetCode](https://leetcode.com/)

--- a/Programming-in-Python.md
+++ b/Programming-in-Python.md
@@ -107,6 +107,10 @@
 - [NumPy aware dynamic Python compiler using LLVM ](https://github.com/ameroueh/numba) | [Numba](http://numba.pydata.org/)
 - [Profiling in Python](https://github.com/mkunesch/profiling-talk) - by [Markus Kunesch](https://github.com/mkunesch)
 
+## Competitions & coding challenges
+
+See [Competitions > Coding challenges](./competitions.md#coding-challenges)
+
 # Contributing
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Awesome Artificial Intelligence, Machine Learning and Deep Learning as we learn 
   - [General](README-details.md#general)
   - [Artificial Intelligence](README-details.md#artificial-intelligence)
   - [Automation](README-details.md#automation)
+  - [Competitions](competitions.md)
   - [Ethics / altruistic motives](README-details.md#ethics--altruistic-motives)
   - [Java](README-details.md#java)
     - [Business / General / Semi-technical](README-details.md#business--general--semi-technical)

--- a/competitions.md
+++ b/competitions.md
@@ -1,0 +1,31 @@
+# Competitions: AI, ML, DL, DS
+
+- [Kaggle competitions](https://www.kaggle.com/competitions)
+    - [Closed DS Competition: CareerVillage](https://www.kaggle.com/c/data-science-for-good-careervillage)
+    - [Closed DS Competition: City of Los Angeles](https://www.kaggle.com/c/data-science-for-good-city-of-los-angeles)
+- [Bitgrit competition platform](https://competition.bitgrit.net/)
+- [CrowdAI](https://www.crowdai.org/challenges?challenge_filter=active)
+- [Crowd Analytix](https://www.crowdanalytix.com/community)
+- [CodaLab](http://codalab.org/)
+- [DataKind DataDives](https://www.datakind.org/datadives)
+- [DataScience.net](http://datascience.net/)
+- [Data Science Challenge](https://www.datasciencechallenge.org/)
+- [Driven Data](https://www.drivendata.org/competitions/)
+- [Pivigo Challenges](https://www.pivigo.com/dashboard/#/challenges/)
+- [Analytics, Data Science, Data Mining Competitions](https://www.kdnuggets.com/competitions/)
+- [DATA SCIENCE COMPETITIONS by Analytics Vidhya](https://www.analyticsvidhya.com/blog/tag/data-science-competitions/)
+- [Signate Competitions (Japanese)](https://signate.jp/competitions/)
+- [Best kept secret about data science competitions by Vincent Granville](https://www.datasciencecentral.com/group/resources/forum/topics/best-kept-secret-about-data-science-competitions)
+- [MPP Capstone Challenge](https://www.datasciencecapstone.org/)
+- [Topcoder Data Science & Analytics competitions](https://www.topcoder.com/community/data-science/)
+- [data-science-competitions on github](https://github.com/data-science-competitions)
+- [Data Science Bowl](https://datasciencebowl.com/)
+- [Data science competition platforms you need to know about](https://medium.com/@opetundeadepoju/data-science-competition-platforms-you-need-to-know-about-55b6840c087e)
+- [KDD Data mining and Knowledge Discovery cup](http://www.kdd.org/kdd-cup)
+- [VizDoom AI competition](http://vizdoom.cs.put.edu.pl/competition-cig-2017)
+
+## Coding challenges
+
+- [Hacker Rank](https://lnkd.in/gEufBUu)
+- [Codeacademy](https://lnkd.in/gGQ7cuv)
+- [LeetCode](https://leetcode.com/)


### PR DESCRIPTION
Adding competition site links to the new page and linking it to the Programming in Python and Main pages, removing the old competition-related page