### PR TITLE
Splitting readm es into smaller files

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -125,16 +125,7 @@ See [Programs and Tools](programs-and-tools.md#programs-and-tools)
 
 ## Databases
 
-- [Grakn and Graql](http://grakn.ai/) - not just graphs, or graph database knowledge graphs | [Docs | Quick start](https://dev.grakn.ai/docs/general/quickstart) | [GitHub](https://github.com/graknlabs/grakn)
-    + See [example](../examples/data/databases/graph/grakn/README.md) in the `../examples/data/databases/graph/grakn` folder
-- [Redis Graph](https://oss.redislabs.com/redisgraph/) | [Blogs](https://blog.grakn.ai/?gi=d6874fc57ebb) | [Videos](https://www.youtube.com/channel/UCtZKw0RFof3x23KqGtW3yDA) | [Skillsmatter: how redis enterprise made redis highly available, scalable, durable and cloudnative](https://skillsmatter.com/skillscasts/11886-how-redis-enterprise-made-redis-highly-available-scalable-durable-and-cloudnative)
-- [Neo4j](https://neo4j.com/)
-- [Gun: A realtime, decentralized, offline-first, mutable graph database engine](https://github.com/amark/gun)
-- [Cayley: An open-source graph database](https://github.com/cayleygraph/cayley)
-
-### Time-series databases
-- [Time-scale](https://www.timescale.com/)
-- [kdb+](https://en.wikipedia.org/wiki/Kdb%2B) - is a column-based relational time series database (TSDB) with in-memory (IMDB) abilities, developed and marketed by [Kx Systems](https://kx.com/)
+See [Databases](./databases.md)
 
 ## References
 

--- a/data/README.md
+++ b/data/README.md
@@ -135,7 +135,6 @@ See under [Cheatsheets](../README-details.md#cheatsheets)
 - [Coursera Course: Probability and distribution](
 https://media.licdn.com/dms/document/C511FAQGFKgIKuW_EEA/feedshare-document-pdf-analyzed/0?e=1571785200&v=beta&t=XyEEqUgi3y4L1hiZ7CxlxbAXyZmM_zcCCdn-Lr04ns8)
 
-
 ## Best practices / rules / an unordered list of high level or low level guidelines
 - [12 Best Practices for Modern Data Ingestion](https://go.streamsets.com/dzone-wp-12-best-practices-modern-data-ingestion)
     - [PDF](https://streamsets.com/wp-content/uploads/2018/01/WP-12-best-practices-for-modern-data-ingestion.pdf)
@@ -144,40 +143,11 @@ https://media.licdn.com/dms/document/C511FAQGFKgIKuW_EEA/feedshare-document-pdf-
 
 ## Framework(s) / checklist(s)
 
-- [Data Science Primer](https://elitedatascience.com/primer)
-- [How to Prepare Data For Machine Learning](https://machinelearningmastery.com/how-to-prepare-data-for-machine-learning/)
-- [What is Data Mining and KDD](https://machinelearningmastery.com/what-is-data-mining-and-kdd/)
-- [The KDD process for extracting useful knowledge from volumes of data](http://shawndra.pbworks.com/f/The%20KDD%20process%20for%20extracting%20useful%20knowledge%20from%20volumes%20of%20data.pdf)
-- [Data Mining: Practical ML Tools and Techniques by Witten, Frank and Mark 3rd edition](https://www.wi.hs-wismar.de/~cleve/vorl/projects/dm/ss13/HierarClustern/Literatur/WittenFrank-DM-3rd.pdf)
-- [Foundational Methodology for Data Science - IBM Analytics Whitepaper](https://tdwi.org/~/media/64511A895D86457E964174EDC5C4C7B1.PDF)
-- [Coursera Data Science Methodology course](https://www.coursera.org/learn/data-science-methodology?aid=true)
-    - From Problem to Approach and From Requirements to Collection
-        - Business Understanding
-        - Analytic Approach
-        - Data Requirements
-        - Data Collection
-    - From Understanding to Preparation and From Modeling to Evaluation
-        - Data Understanding
-        - Data Preparation
-        - Modeling 
-        - Model Evaluation
+See [Framework(s) / checklist(s)](./frameworks-checklists.md)
 
 ## Notebooks
 
-- [Python Data Science Handbook on Azure git repo](https://notebooks.azure.com/jakevdp/projects/PythonDataScienceHandbook/tree/notebooks)
-- [Python for Data Analysis on Azure git repo](https://notebooks.azure.com/wesm/projects/python-for-data-analysis)
-- [Python Data Science Handbook](https://jakevdp.github.io/PythonDataScienceHandbook/)
-- House prices
-    - [ML End-to-End Tutorial + Pandas notebook](../notebooks/data/DSfIOT_Machine_Learning_End_to_End_Tutorial.ipynb)
-    - [Regression example notebook](https://colab.research.google.com/drive/19uoDyGAxJ0zCwPT6cNb1xkYOfySNZChV)
-    - [Classification example notebook](https://colab.research.google.com/drive/1i-fOhU87wWrzgnTV0o54MQyHmRVJK0qt)
-    - Some explanations of the above Regression & Classification examples: [as a Notebook](https://drive.google.com/file/d/1vR9fOsWkCx0PuiCH0Eiz5FG1AAHuBHa8/view) | [as a PDF file](https://drive.google.com/file/d/1U3GkVgloBd5-w4qSj0KcyhtalhDF7pgC/view)
-- [Data science Python notebooks: Deep learning (TensorFlow, Theano, Caffe, Keras), scikit-learn, Kaggle, big data (Spark, Hadoop MapReduce, HDFS), matplotlib, pandas, NumPy, SciPy, Python essentials, AWS, and various command line tools](https://github.com/donnemartin/data-science-ipython-notebooks)
-- [Synthetic features and outliers notebook](https://colab.research.google.com/notebooks/mlcc/synthetic_features_and_outliers.ipynb?utm_source=mlcc&utm_campaign=colab-external&utm_medium=referral&utm_content=syntheticfeatures-colab&hl=en#scrollTo=jnKgkN5fHbGy)
-- Do we know our data...
-  - [Exploratory Data Analysis](../notebooks/jupyter/data/01_Exploratory_Data_Analysis_(Do_we_know_our_data).ipynb)
-  - [Data Preparation](../notebooks/jupyter/data/02_Data_Preparation_(Do_we_know_our_data).ipynb)
-  - [Feature Engineering](../notebooks/jupyter/data/03_Feature_Engineering_(Do_we_know_our_data).ipynb) 
+See [Notebooks](./notebooks.md)
 
 ## Programs and Tools
 

--- a/data/README.md
+++ b/data/README.md
@@ -96,45 +96,7 @@ See [Data Generation](./data-generation.md#data-generation)
 
 ## Post model-creation analysis, ML interpretation/explainability
 
-### Libraries & packages
-
-- [Yellowbrick](https://www.scikit-yb.org/en/latest/#yellowbrick-machine-learning-visualization) - is a suite of visual diagnostic tools called “Visualizers” that extend the Scikit-Learn API to allow human steering of the model selection process
-- [Shap](https://github.com/slundberg/shap) - A unified approach to explain the output of any machine learning model
-- [LIME](https://github.com/marcotcr/lime)
-- [4 Python Libraries For Getting Better Model Interpretability](https://www.analyticsindiamag.com/4-python-libraries-for-getting-better-model-interpretability/)
-- [Integrated Gradients: Axiomatic Attribution for Deep Networks](https://github.com/ankurtaly/Integrated-Gradients) | [Paper](https://arxiv.org/abs/1703.01365)
-- [Resources on GitHub on interpretability](https://github.com/topics/interpretability)
-- [Awesome Machine Learning Interpretability](https://github.com/jphall663/awesome-machine-learning-interpretability) - A Curated, but Probably Biased and Incomplete, List of Awesome Machine Learning Interpretability Resources
-
-### Articles, blog posts, papers, notebooks, books, presentations
-
-- [DataRobot: Model Interpretability - What is Model Interpretability in Machine Learning?](https://www.datarobot.com/wiki/interpretability/)
-- [Model Interpretability with SHAP](http://www.f1-predictor.com/model-interpretability-with-shap/)
-- [Interpreting bag of words models with SHAP](https://sararobinson.dev/2019/04/23/interpret-bag-of-words-models-shap.html)
-- [Explain any machine learning model prediction - using SHAP](https://towardsdatascience.com/how-to-explain-any-machine-learning-model-prediction-30654b0c1c8)
-- [Explain ML Models notebooks](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/explain-model)
-- [How to explain the prediction of a ML model](https://lilianweng.github.io/lil-log/2017/08/01/how-to-explain-the-prediction-of-a-machine-learning-model.html)
-- [Explaining complex machine learning models with LIME](https://datascienceplus.com/explaining-complex-machine-learning-models-with-lime/)
-- Hermeneutic Investigations: ML Interpreation - why?: [Video](https://www.youtube.com/watch?v=pmdYlahqA_g) | [Slides](https://github.com/daplantagenet/iml.github.io/blob/master/Hermeneutic%20Investigations.pdf) by [Dean Allsopp](http://github.com/daplantagenet)
-- [Explaining Explanations: An Overview ofInterpretability of Machine Learning](https://arxiv.org/pdf/1806.00069.pdf)
-- [Explaining Black-Box Machine Learning Models](https://shirinsplayground.netlify.com/2018/07/explaining_ml_models_code_caret_iml/)
-- [Interpretable Machine Learning](https://christophm.github.io/interpretable-ml-book/)
-- [R Machine Learning Projects by Dr. Sunil Kumar Chinnamgari: Model interpretability](https://www.oreilly.com/library/view/r-machine-learning/9781789807943/dcd398be-3488-423c-942c-69d1eac253f5.xhtml)
-- [Hands-on Machine Learning with R: Interpretable Machine Learning](https://bradleyboehmke.github.io/HOML/iml.html)
-- Tree SHAP
-  - [Consistent Individualized Feature Attribution for Tree Ensembles ](https://arxiv.org/abs/1802.03888)
-  - [Consistent feature attribution for tree ensembles](https://arxiv.org/abs/1706.06060)
-- [Exact SHAP: A Unified Approach to Interpreting Model Predictions](https://arxiv.org/abs/1705.07874)
-- [Integrated Gradients: Axiomatic Attribution for Deep Networks](https://arxiv.org/abs/1703.01365) | [GitHub](https://github.com/ankurtaly/Integrated-Gradients)
-- [Know Data Science](https://www.linkedin.com/feed/update/urn:li:activity:6516283940658089984)
-- [Understand How to answer Why](https://www.linkedin.com/feed/update/urn:li:activity:6519055798948204544)
-- [Learning with Explanations](https://www.youtube.com/watch?v=m1GUhPgstvk) by [Tim Rocktäschel](https://rockt.github.io/)
-- Towards Explainable AI: [Slides](../presentations/data/03-meetup-uk-2019/Towards-Explainable-AI.pdf) | [Video](https://www.youtube.com/watch?v=0yFjSs-azM4) | [Book: A Concise Introduction to Machine Learning](https://www.amazon.co.uk/Concise-Introduction-Machine-Learning/dp/0815384106/ref=tmm_pap_swatch_0?_encoding=UTF8&qid=1566160069&sr=8-2) by [Anita Faul](https://www.linkedin.com/in/anita-faul-123750104/)
-- [Machine Learning Project End to End with Python Code (data science focussed)](https://www.youtube.com/watch?v=ekV9QO5KHUY&list=PLcQCwsZDEzFkP9WMe6xvLrd_ZNGqoXOQY&fbclid=IwAR1z7XBl762FLyo-gVvdBDU1iCVqz89K1yfmJS1cbC4rZyEfF-jO30ZsYeY)
-    - Python Project (Classification) : 
-      - Part A: https://www.youtube.com/watch?v=p0snNMCbvN4&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=8
-      - Part B: https://www.youtube.com/watch?v=j4IgXflsZtg&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=9
-      - Part C: https://www.youtube.com/watch?v=kHZmFVDm0QQ&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=10
+See [Post model-creation analysis, ML interpretation/explainability](./model-analysis-interpretation-explainability.md)
 
 ## Statistics
 

--- a/data/README.md
+++ b/data/README.md
@@ -41,31 +41,7 @@ See [Ethics / altruistic motives](../README-details.md#ethics--altruistic-motive
 
 ## Datasets and sources of raw data
 
-### Raw / unclean datasets
-
-- [Boston Housing Dataset (archive contains unclean dataset)](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/tag/v0.1) | [Download](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/download/v0.1/boston_housing_dataset.zip)
-- [Datasets for Data cleaning practise](https://makingnoiseandhearingthings.com/2018/04/19/datasets-for-data-cleaning-practice/)
-- [Cleaning up and combining data, a dataset for practice](https://www.r-bloggers.com/cleaning-up-and-combining-data-a-dataset-for-practice/)
-- [Datasets from various themes and domains: retail, government. Datasets with a good mix of incorrect, wrongly-input, missing data](https://www.ud-intl.com/dataset)
-- [(Specific) Web Traffic Time Series Forecasting](https://www.kaggle.com/c/web-traffic-time-series-forecasting)
-- [Quora: What are some dirty/untidy datasets to clean for data analysis? I have just finished datacamp's course on cleaning data using R. I want to practice](https://www.quora.com/What-are-some-dirty-untidy-datasets-to-clean-for-data-analysis-I-have-just-finished-datacamps-course-on-cleaning-data-using-R-I-want-to-practice)
-
-### Clean / ready-to-use datasets
-
-- [Boston Housing Dataset (archive contains clean dataset)](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/tag/v0.1) | [Download](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/download/v0.1/boston_housing_dataset.zip)
-- [Google Dataset Search](https://toolbox.google.com/datasetsearch)
-- [Kaggle Datasets](https://www.kaggle.com/datasets) | Blogs: [1](https://towardsdatascience.com/interesting-datasets-on-kaggle-com-3a4a250b0b85) [2](http://blog.kaggle.com/2016/01/19/introducing-kaggle-datasets/) [3](https://medium.com/@benhamner/introducing-kaggle-datasets-a935f9f76f5) [4](https://stackoverflow.com/questions/52681196/kaggle-datasets-into-jupyter-notebook)
-- [Carnegie Mellon University Datasets](http://lib.stat.cmu.edu/datasets/)
-- [GeoPlatform Data.gov Search ](https://data.geoplatform.gov/)
-- [Data.gov - Data Catalog](https://catalog.data.gov/dataset)
-- [TidyTuesday projects on GitHub](https://github.com/rfordatascience/tidytuesday)
-- [Enron Email Digest Dataset](https://www.cs.cmu.edu/~enron/)
-- [Mathematics Datasets](https://github.com/deepmind/mathematics_dataset)
-- [Data.world datasets](https://data.world)
-- [Microsoft Research Open Data](https://msropendata.com/)
-- [Free Datasets recommended by r-directory](https://r-dir.com/reference/datasets.html)
-- [UC Irvine Machine Learning Repository](https://archive.ics.uci.edu/ml/index.php)
-- [Google Research: A large-scale dataset of manually annotated audio events](https://research.google.com/audioset/index.html)
+See [Datasets](./datasets.md)
 
 ## Data Exploratory Analysis
 
@@ -84,24 +60,7 @@ See [Ethics / altruistic motives](../README-details.md#ethics--altruistic-motive
 
 ## Data preparation
 
-### Data cleaning
-
-- [Data cleaning](https://elitedatascience.com/data-cleaning)
-- [Spend Less Time Cleaning Data with Machine Learning](https://www.dataversity.net/spend-less-time-cleaning-data-with-machine-learning/#)
-- [Helpful Python Code Snippets for Data Exploration in Pandas](https://medium.com/@msalmon00/helpful-python-code-snippets-for-data-exploration-in-pandas-b7c5aed5ecb9) - lots of python snippets to select / clean / prepare
-- [Working with missing data](https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html)
-- [Journal of Statistical Software - TidyData](https://www.jstatsoft.org/article/view/v059i10/)
-- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
-- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
-
-### Data preprocessing / Data wrangling / Data manipulation
-
-- [Data Preprocessing vs. Data Wrangling in Machine Learning Projects](https://www.infoq.com/articles/ml-data-processing)
-- [Improve Model Accuracy with Data Pre-Processing](https://machinelearningmastery.com/improve-model-accuracy-with-data-pre-processing/)
-- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
-- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
-- [Pandas](https://lnkd.in/gxSgfuQ)
-- [SQLAlchemy](https://lnkd.in/gjvbm7h)
+See [Data preparation](./data-preparation.md)
 
 ### Misc
 

--- a/data/README.md
+++ b/data/README.md
@@ -45,27 +45,11 @@ See [Datasets](./datasets.md)
 
 ## Data Exploratory Analysis
 
-- [The Ultimate Python Seaborn Tutorial: Gotta Catch ‘Em All](https://elitedatascience.com/python-seaborn-tutorial)
-- [Exploratory Analysis](https://elitedatascience.com/exploratory-analysis)
-- [Understand Your Machine Learning Data With Descriptive Statistics in Python](https://machinelearningmastery.com/understand-machine-learning-data-descriptive-statistics-python/)
-- [Visualize Machine Learning Data in Python With Pandas](https://machinelearningmastery.com/visualize-machine-learning-data-python-pandas/)
-- [8 Tactics to Combat Imbalanced Classes in Your Machine Learning Dataset](https://machinelearningmastery.com/tactics-to-combat-imbalanced-classes-in-your-machine-learning-dataset/)
-- [Exploring and Transforming H2O DataFrame in R and Python](https://dzone.com/articles/exploring-amp-transforming-h2o-data-frame-in-r-and)
-- [ML with H2O by Sudalai Rajkumar](https://www.slideshare.net/0xdata/machine-learning-with-h2o-114163519) (slide 20 onwards)
-- [How to Use Statistics to Identify Outliers in Data](https://machinelearningmastery.com/how-to-use-statistics-to-identify-outliers-in-data/)
-- [Fundamentals of Data Visualization](https://serialmentor.com/dataviz/)
-- [Helpful Python Code Snippets for Data Exploration in Pandas](https://medium.com/@msalmon00/helpful-python-code-snippets-for-data-exploration-in-pandas-b7c5aed5ecb9)
-- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
-- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/01-mam-ml-study-group-meetup/01-mam-ml-study-group-meetup/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
+See [Data Exploratory Analysis](./data-exploratory-analysis.md)
 
 ## Data preparation
 
 See [Data preparation](./data-preparation.md)
-
-### Misc
-
-- See discussion on [how data cleaning/preprocessing](https://www.meetup.com/Kaggle-Days-Meetup-London/events/258570474/comments/500079284/?read=1&_xtd=gatlbWFpbF9jbGlja9oAJDczM2Q5MDExLWYyZTctNDliNy1hZTgzLTk5NjFlMGViOGQ4Mw&itemTypeToken=COMMENT) went wrong resulting in poorly performing model
-- [Learning with Limited Labeled Data with Shioulin Sam](https://twimlai.com/twiml-talk-255-learning-with-limited-labeled-data-with-shioulin-sam/)
 
 ## Data Generation
 
@@ -73,26 +57,11 @@ See [Data Generation](./data-generation.md#data-generation)
 
 ## Feature Selection
 
-- [Feature selection with mutual information](http://www.simafore.com/blog/bid/105347/Feature-selection-with-mutual-information-Part-2-PCA-disadvantages)
-- Forward Feature selection: [Blog on Towards DS](https://towardsdatascience.com/feature-importance-and-forward-feature-selection-752638849962) | [Scikit learn](https://mikulskibartosz.name/forward-feature-selection-in-scikit-learn-f6476e474ddd)
-- [What is dimensionality reduction? What is the difference between feature selection and extraction?](https://datascience.stackexchange.com/questions/130/what-is-dimensionality-reduction-what-is-the-difference-between-feature-selecti)
-- [Feature Engineering and Feature Selection](https://media.licdn.com/dms/document/C511FAQF45u2wk4WYKQ/feedshare-document-pdf-analyzed/0?e=1570834800&v=beta&t=lNVqtm3JJYvvPHpsl0uc6mZJjVGWgJ8Toz29tNJA4GI)
+See [Feature Selection](./feature-selection.md)
 
 ## Feature engineering
 
-- [Basic Feature Engineering With Time Series Data in Python](http://machinelearningmastery.com/basic-feature-engineering-time-series-data-python/)
-- [Zillow Prize - EDA, Data Cleaning & Feature Engineering](https://www.kaggle.com/lauracozma/eda-data-cleaning-feature-engineering)
-- [Feature-wise transformations](https://distill.pub/2018/feature-wise-transformations)
-- [tsfresh](https://tsfresh.readthedocs.io/en/latest/text/introduction.html) - tsfresh is used to to extract characteristics from time series
-- [featuretools](https://github.com/featuretools/featuretools/) - an open source python framework for automated feature engineering
-- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
-- [scikit learn's SelectKBest](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.SelectKBest.html)
-- [mlbox's Feature selection](https://mlbox.readthedocs.io/en/latest/features.html)
-- Chi2 test: Feature selection: [Quora](https://www.quora.com/How-is-chi-test-used-for-feature-selection-in-machine-learning) | [NLP Stanford Group](https://nlp.stanford.edu/IR-book/html/htmledition/feature-selectionchi2-feature-selection-1.html) | [Learn for Master](http://www.learn4master.com/machine-learning/chi-square-test-for-feature-selection)
-- [Feature engineering and Dimensionality reduction](https://towardsdatascience.com/dimensionality-reduction-for-machine-learning-80a46c2ebb7e)
-- [Seven Techniques for Data Dimensionality Reduction](https://www.kdnuggets.com/2015/05/7-methods-data-dimensionality-reduction.html)
-- [Feature Engineering and Feature Selection](https://media.licdn.com/dms/document/C511FAQF45u2wk4WYKQ/feedshare-document-pdf-analyzed/0?e=1570834800&v=beta&t=lNVqtm3JJYvvPHpsl0uc6mZJjVGWgJ8Toz29tNJA4GI)
-- [ML topics expanded by Chris Albon](https://chrisalbon.com/#machine_learning) - look for topics: Feature Engineering • Feature Selection
+See [Feature engineering](./feature-engineering.md)
 
 ## Post model-creation analysis, ML interpretation/explainability
 
@@ -136,6 +105,7 @@ See under [Cheatsheets](../README-details.md#cheatsheets)
 https://media.licdn.com/dms/document/C511FAQGFKgIKuW_EEA/feedshare-document-pdf-analyzed/0?e=1571785200&v=beta&t=XyEEqUgi3y4L1hiZ7CxlxbAXyZmM_zcCCdn-Lr04ns8)
 
 ## Best practices / rules / an unordered list of high level or low level guidelines
+
 - [12 Best Practices for Modern Data Ingestion](https://go.streamsets.com/dzone-wp-12-best-practices-modern-data-ingestion)
     - [PDF](https://streamsets.com/wp-content/uploads/2018/01/WP-12-best-practices-for-modern-data-ingestion.pdf)
 - [A Rubric for ML Production Readiness - by Jiameng Gao from Applied Deep Learning Meetup in Feb 2019](https://docs.google.com/presentation/d/1-4gE9v1X7EP4rsBQlRtGA9IXDnBjlQPAqB3jlDBvUTU/edit#slide=id.p) (Paper: https://ai.google/research/pubs/pub46555)
@@ -154,6 +124,7 @@ See [Notebooks](./notebooks.md)
 See [Programs and Tools](programs-and-tools.md#programs-and-tools)
 
 ## Databases
+
 - [Grakn and Graql](http://grakn.ai/) - not just graphs, or graph database knowledge graphs | [Docs | Quick start](https://dev.grakn.ai/docs/general/quickstart) | [GitHub](https://github.com/graknlabs/grakn)
     + See [example](../examples/data/databases/graph/grakn/README.md) in the `../examples/data/databases/graph/grakn` folder
 - [Redis Graph](https://oss.redislabs.com/redisgraph/) | [Blogs](https://blog.grakn.ai/?gi=d6874fc57ebb) | [Videos](https://www.youtube.com/channel/UCtZKw0RFof3x23KqGtW3yDA) | [Skillsmatter: how redis enterprise made redis highly available, scalable, durable and cloudnative](https://skillsmatter.com/skillscasts/11886-how-redis-enterprise-made-redis-highly-available-scalable-durable-and-cloudnative)

--- a/data/README.md
+++ b/data/README.md
@@ -91,18 +91,9 @@ See [Visualisation](../README-details.md#visualisation-1)
 
 See under [Cheatsheets](../README-details.md#cheatsheets)
 
-## Course / books
+## Courses / books
 
-- [Data Science Primer](https://elitedatascience.com/primer)
-- [27 Amazing Data Science Books Every Data Scientist Should Read](https://www.analyticsvidhya.com/blog/2019/01/27-amazing-data-science-books-every-data-scientist-should-read/)
-- [Coursera course: Getting and Cleaning Data](https://www.coursera.org/learn/data-cleaning?recoOrder=20&utm_medium=email&utm_source=recommendations&utm_campaign=u0faoCsqEemEkbug8nMVQQ)
-- [Data Science courses on Coursera](https://www.coursera.org/learn/competitive-data-science)
-- [Data courses on Udemy](https://www.udemy.com/courses/search/?ref=home&src=ukw&q=data)
-- [Data courses on Udacity](https://eu.udacity.com/courses/school-of-data-science)
-- [Latest Machine learning, visualization, data mining techniques. Online Masters in Data Analytic from Penn State](https://twitter.com/analyticbridge/status/1102667686302179336)
-- [Data Science Handbook](https://github.com/RishiSankineni/Data-Science-Swag/blob/master/The%20Data%20Science%20Handbook.pdf)
-- [Coursera Course: Probability and distribution](
-https://media.licdn.com/dms/document/C511FAQGFKgIKuW_EEA/feedshare-document-pdf-analyzed/0?e=1571785200&v=beta&t=XyEEqUgi3y4L1hiZ7CxlxbAXyZmM_zcCCdn-Lr04ns8)
+See [Courses / books](./courses-books.md)
 
 ## Best practices / rules / an unordered list of high level or low level guidelines
 

--- a/data/courses-books.md
+++ b/data/courses-books.md
@@ -1,0 +1,24 @@
+# Courses / books
+
+- [Data Science Primer](https://elitedatascience.com/primer)
+- [27 Amazing Data Science Books Every Data Scientist Should Read](https://www.analyticsvidhya.com/blog/2019/01/27-amazing-data-science-books-every-data-scientist-should-read/)
+- [Coursera course: Getting and Cleaning Data](https://www.coursera.org/learn/data-cleaning?recoOrder=20&utm_medium=email&utm_source=recommendations&utm_campaign=u0faoCsqEemEkbug8nMVQQ)
+- [Data Science courses on Coursera](https://www.coursera.org/learn/competitive-data-science)
+- [Data courses on Udemy](https://www.udemy.com/courses/search/?ref=home&src=ukw&q=data)
+- [Data courses on Udacity](https://eu.udacity.com/courses/school-of-data-science)
+- [Latest Machine learning, visualization, data mining techniques. Online Masters in Data Analytic from Penn State](https://twitter.com/analyticbridge/status/1102667686302179336)
+- [Data Science Handbook](https://github.com/RishiSankineni/Data-Science-Swag/blob/master/The%20Data%20Science%20Handbook.pdf)
+- [Coursera Course: Probability and distribution](
+https://media.licdn.com/dms/document/C511FAQGFKgIKuW_EEA/feedshare-document-pdf-analyzed/0?e=1571785200&v=beta&t=XyEEqUgi3y4L1hiZ7CxlxbAXyZmM_zcCCdn-Lr04ns8)
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/data-exploratory-analysis.md
+++ b/data/data-exploratory-analysis.md
@@ -1,0 +1,28 @@
+# Data Exploratory Analysis
+
+aka *_Exploratory Data Analysis_*
+
+- [The Ultimate Python Seaborn Tutorial: Gotta Catch ‘Em All](https://elitedatascience.com/python-seaborn-tutorial)
+- [Exploratory Analysis](https://elitedatascience.com/exploratory-analysis)
+- [Understand Your Machine Learning Data With Descriptive Statistics in Python](https://machinelearningmastery.com/understand-machine-learning-data-descriptive-statistics-python/)
+- [Visualize Machine Learning Data in Python With Pandas](https://machinelearningmastery.com/visualize-machine-learning-data-python-pandas/)
+- [8 Tactics to Combat Imbalanced Classes in Your Machine Learning Dataset](https://machinelearningmastery.com/tactics-to-combat-imbalanced-classes-in-your-machine-learning-dataset/)
+- [Exploring and Transforming H2O DataFrame in R and Python](https://dzone.com/articles/exploring-amp-transforming-h2o-data-frame-in-r-and)
+- [ML with H2O by Sudalai Rajkumar](https://www.slideshare.net/0xdata/machine-learning-with-h2o-114163519) (slide 20 onwards)
+- [How to Use Statistics to Identify Outliers in Data](https://machinelearningmastery.com/how-to-use-statistics-to-identify-outliers-in-data/)
+- [Fundamentals of Data Visualization](https://serialmentor.com/dataviz/)
+- [Helpful Python Code Snippets for Data Exploration in Pandas](https://medium.com/@msalmon00/helpful-python-code-snippets-for-data-exploration-in-pandas-b7c5aed5ecb9)
+- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
+- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/01-mam-ml-study-group-meetup/01-mam-ml-study-group-meetup/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/data-preparation.md
+++ b/data/data-preparation.md
@@ -1,0 +1,31 @@
+# Data preparation
+
+## Data cleaning
+
+- [Data cleaning](https://elitedatascience.com/data-cleaning)
+- [Spend Less Time Cleaning Data with Machine Learning](https://www.dataversity.net/spend-less-time-cleaning-data-with-machine-learning/#)
+- [Helpful Python Code Snippets for Data Exploration in Pandas](https://medium.com/@msalmon00/helpful-python-code-snippets-for-data-exploration-in-pandas-b7c5aed5ecb9) - lots of python snippets to select / clean / prepare
+- [Working with missing data](https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html)
+- [Journal of Statistical Software - TidyData](https://www.jstatsoft.org/article/view/v059i10/)
+- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
+- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
+
+## Data preprocessing / Data wrangling / Data manipulation
+
+- [Data Preprocessing vs. Data Wrangling in Machine Learning Projects](https://www.infoq.com/articles/ml-data-processing)
+- [Improve Model Accuracy with Data Pre-Processing](https://machinelearningmastery.com/improve-model-accuracy-with-data-pre-processing/)
+- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
+- [Introduction to Data Analysis and Cleaning presentation](../presentations/data/Introduction_to_Data_Analysis_and_Cleaning.pdf) by [Mark Bell](http://www.nationalarchives.gov.uk/about/our-research-and-academic-collaboration/our-research-and-people/staff-profiles/mark-bell/)
+- [Pandas](https://lnkd.in/gxSgfuQ)
+- [SQLAlchemy](https://lnkd.in/gjvbm7h)
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/data-preparation.md
+++ b/data/data-preparation.md
@@ -23,7 +23,7 @@
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!
 
-Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
 
 ---
 

--- a/data/data-preparation.md
+++ b/data/data-preparation.md
@@ -19,6 +19,11 @@
 - [Pandas](https://lnkd.in/gxSgfuQ)
 - [SQLAlchemy](https://lnkd.in/gjvbm7h)
 
+## Misc
+
+- See discussion on [how data cleaning/preprocessing](https://www.meetup.com/Kaggle-Days-Meetup-London/events/258570474/comments/500079284/?read=1&_xtd=gatlbWFpbF9jbGlja9oAJDczM2Q5MDExLWYyZTctNDliNy1hZTgzLTk5NjFlMGViOGQ4Mw&itemTypeToken=COMMENT) went wrong resulting in poorly performing model
+- [Learning with Limited Labeled Data with Shioulin Sam](https://twimlai.com/twiml-talk-255-learning-with-limited-labeled-data-with-shioulin-sam/)
+
 # Contributing
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!

--- a/data/databases.md
+++ b/data/databases.md
@@ -1,0 +1,23 @@
+# Databases
+
+- [Grakn and Graql](http://grakn.ai/) - not just graphs, or graph database knowledge graphs | [Docs | Quick start](https://dev.grakn.ai/docs/general/quickstart) | [GitHub](https://github.com/graknlabs/grakn)
+    + See [example](../examples/data/databases/graph/grakn/README.md) in the `../examples/data/databases/graph/grakn` folder
+- [Redis Graph](https://oss.redislabs.com/redisgraph/) | [Blogs](https://blog.grakn.ai/?gi=d6874fc57ebb) | [Videos](https://www.youtube.com/channel/UCtZKw0RFof3x23KqGtW3yDA) | [Skillsmatter: how redis enterprise made redis highly available, scalable, durable and cloudnative](https://skillsmatter.com/skillscasts/11886-how-redis-enterprise-made-redis-highly-available-scalable-durable-and-cloudnative)
+- [Neo4j](https://neo4j.com/)
+- [Gun: A realtime, decentralized, offline-first, mutable graph database engine](https://github.com/amark/gun)
+- [Cayley: An open-source graph database](https://github.com/cayleygraph/cayley)
+
+### Time-series databases
+- [Time-scale](https://www.timescale.com/)
+- [kdb+](https://en.wikipedia.org/wiki/Kdb%2B) - is a column-based relational time series database (TSDB) with in-memory (IMDB) abilities, developed and marketed by [Kx Systems](https://kx.com/)
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -1,0 +1,39 @@
+# Datasets and sources of raw data
+
+## Raw / unclean datasets
+
+- [Boston Housing Dataset (archive contains unclean dataset)](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/tag/v0.1) | [Download](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/download/v0.1/boston_housing_dataset.zip)
+- [Datasets for Data cleaning practise](https://makingnoiseandhearingthings.com/2018/04/19/datasets-for-data-cleaning-practice/)
+- [Cleaning up and combining data, a dataset for practice](https://www.r-bloggers.com/cleaning-up-and-combining-data-a-dataset-for-practice/)
+- [Datasets from various themes and domains: retail, government. Datasets with a good mix of incorrect, wrongly-input, missing data](https://www.ud-intl.com/dataset)
+- [(Specific) Web Traffic Time Series Forecasting](https://www.kaggle.com/c/web-traffic-time-series-forecasting)
+- [Quora: What are some dirty/untidy datasets to clean for data analysis? I have just finished datacamp's course on cleaning data using R. I want to practice](https://www.quora.com/What-are-some-dirty-untidy-datasets-to-clean-for-data-analysis-I-have-just-finished-datacamps-course-on-cleaning-data-using-R-I-want-to-practice)
+
+## Clean / ready-to-use datasets
+
+- [Boston Housing Dataset (archive contains clean dataset)](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/tag/v0.1) | [Download](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/download/v0.1/boston_housing_dataset.zip)
+- [Google Dataset Search](https://toolbox.google.com/datasetsearch)
+- [Kaggle Datasets](https://www.kaggle.com/datasets) | Blogs: [1](https://towardsdatascience.com/interesting-datasets-on-kaggle-com-3a4a250b0b85) [2](http://blog.kaggle.com/2016/01/19/introducing-kaggle-datasets/) [3](https://medium.com/@benhamner/introducing-kaggle-datasets-a935f9f76f5) [4](https://stackoverflow.com/questions/52681196/kaggle-datasets-into-jupyter-notebook)
+- [Carnegie Mellon University Datasets](http://lib.stat.cmu.edu/datasets/)
+- [GeoPlatform Data.gov Search ](https://data.geoplatform.gov/)
+- [Data.gov - Data Catalog](https://catalog.data.gov/dataset)
+- [TidyTuesday projects on GitHub](https://github.com/rfordatascience/tidytuesday)
+- [Enron Email Digest Dataset](https://www.cs.cmu.edu/~enron/)
+- [Mathematics Datasets](https://github.com/deepmind/mathematics_dataset)
+- [Data.world datasets](https://data.world)
+- [Microsoft Research Open Data](https://msropendata.com/)
+- [Free Datasets recommended by r-directory](https://r-dir.com/reference/datasets.html)
+- [UC Irvine Machine Learning Repository](https://archive.ics.uci.edu/ml/index.php)
+- [Google Research: A large-scale dataset of manually annotated audio events](https://research.google.com/audioset/index.html)
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -31,7 +31,7 @@
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!
 
-Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
 
 ---
 

--- a/data/feature-engineering.md
+++ b/data/feature-engineering.md
@@ -1,0 +1,27 @@
+# Feature Engineering
+
+- [Basic Feature Engineering With Time Series Data in Python](http://machinelearningmastery.com/basic-feature-engineering-time-series-data-python/)
+- [Zillow Prize - EDA, Data Cleaning & Feature Engineering](https://www.kaggle.com/lauracozma/eda-data-cleaning-feature-engineering)
+- [Feature-wise transformations](https://distill.pub/2018/feature-wise-transformations)
+- [tsfresh](https://tsfresh.readthedocs.io/en/latest/text/introduction.html) - tsfresh is used to to extract characteristics from time series
+- [featuretools](https://github.com/featuretools/featuretools/) - an open source python framework for automated feature engineering
+- [5 Steps to correctly prepare your data for your machine learning model](https://towardsdatascience.com/5-steps-to-correctly-prep-your-data-for-your-machine-learning-model-c06c24762b73?gi=6b4a6895ab1)
+- [scikit learn's SelectKBest](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.SelectKBest.html)
+- [mlbox's Feature selection](https://mlbox.readthedocs.io/en/latest/features.html)
+- Chi2 test: Feature selection: [Quora](https://www.quora.com/How-is-chi-test-used-for-feature-selection-in-machine-learning) | [NLP Stanford Group](https://nlp.stanford.edu/IR-book/html/htmledition/feature-selectionchi2-feature-selection-1.html) | [Learn for Master](http://www.learn4master.com/machine-learning/chi-square-test-for-feature-selection)
+- [Feature engineering and Dimensionality reduction](https://towardsdatascience.com/dimensionality-reduction-for-machine-learning-80a46c2ebb7e)
+- [Seven Techniques for Data Dimensionality Reduction](https://www.kdnuggets.com/2015/05/7-methods-data-dimensionality-reduction.html)
+- [Feature Engineering and Feature Selection](https://media.licdn.com/dms/document/C511FAQF45u2wk4WYKQ/feedshare-document-pdf-analyzed/0?e=1570834800&v=beta&t=lNVqtm3JJYvvPHpsl0uc6mZJjVGWgJ8Toz29tNJA4GI)
+- [ML topics expanded by Chris Albon](https://chrisalbon.com/#machine_learning) - look for topics: Feature Engineering • Feature Selection
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/feature-selection.md
+++ b/data/feature-selection.md
@@ -1,0 +1,18 @@
+# Feature Selection
+
+- [Feature selection with mutual information](http://www.simafore.com/blog/bid/105347/Feature-selection-with-mutual-information-Part-2-PCA-disadvantages)
+- Forward Feature selection: [Blog on Towards DS](https://towardsdatascience.com/feature-importance-and-forward-feature-selection-752638849962) | [Scikit learn](https://mikulskibartosz.name/forward-feature-selection-in-scikit-learn-f6476e474ddd)
+- [What is dimensionality reduction? What is the difference between feature selection and extraction?](https://datascience.stackexchange.com/questions/130/what-is-dimensionality-reduction-what-is-the-difference-between-feature-selecti)
+- [Feature Engineering and Feature Selection](https://media.licdn.com/dms/document/C511FAQF45u2wk4WYKQ/feedshare-document-pdf-analyzed/0?e=1570834800&v=beta&t=lNVqtm3JJYvvPHpsl0uc6mZJjVGWgJ8Toz29tNJA4GI)
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/frameworks-checklists.md
+++ b/data/frameworks-checklists.md
@@ -1,0 +1,32 @@
+# Framework(s) / checklist(s)
+
+- [Data Science Primer](https://elitedatascience.com/primer)
+- [How to Prepare Data For Machine Learning](https://machinelearningmastery.com/how-to-prepare-data-for-machine-learning/)
+- [What is Data Mining and KDD](https://machinelearningmastery.com/what-is-data-mining-and-kdd/)
+- [The KDD process for extracting useful knowledge from volumes of data](http://shawndra.pbworks.com/f/The%20KDD%20process%20for%20extracting%20useful%20knowledge%20from%20volumes%20of%20data.pdf)
+- [Data Mining: Practical ML Tools and Techniques by Witten, Frank and Mark 3rd edition](https://www.wi.hs-wismar.de/~cleve/vorl/projects/dm/ss13/HierarClustern/Literatur/WittenFrank-DM-3rd.pdf)
+- [Foundational Methodology for Data Science - IBM Analytics Whitepaper](https://tdwi.org/~/media/64511A895D86457E964174EDC5C4C7B1.PDF)
+- [Coursera Data Science Methodology course](https://www.coursera.org/learn/data-science-methodology?aid=true)
+    - From Problem to Approach and From Requirements to Collection
+        - Business Understanding
+        - Analytic Approach
+        - Data Requirements
+        - Data Collection
+    - From Understanding to Preparation and From Modeling to Evaluation
+        - Data Understanding
+        - Data Preparation
+        - Modeling 
+        - Model Evaluation
+
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/model-analysis-interpretation-explainability.md
+++ b/data/model-analysis-interpretation-explainability.md
@@ -1,0 +1,41 @@
+# Post model-creation analysis, ML interpretation/explainability
+
+## Libraries & packages
+
+- [Yellowbrick](https://www.scikit-yb.org/en/latest/#yellowbrick-machine-learning-visualization) - is a suite of visual diagnostic tools called “Visualizers” that extend the Scikit-Learn API to allow human steering of the model selection process
+- [Shap](https://github.com/slundberg/shap) - A unified approach to explain the output of any machine learning model
+- [LIME](https://github.com/marcotcr/lime)
+- [4 Python Libraries For Getting Better Model Interpretability](https://www.analyticsindiamag.com/4-python-libraries-for-getting-better-model-interpretability/)
+- [Integrated Gradients: Axiomatic Attribution for Deep Networks](https://github.com/ankurtaly/Integrated-Gradients) | [Paper](https://arxiv.org/abs/1703.01365)
+- [Resources on GitHub on interpretability](https://github.com/topics/interpretability)
+- [Awesome Machine Learning Interpretability](https://github.com/jphall663/awesome-machine-learning-interpretability) - A Curated, but Probably Biased and Incomplete, List of Awesome Machine Learning Interpretability Resources
+
+## Articles, blog posts, papers, notebooks, books, presentations
+
+- [DataRobot: Model Interpretability - What is Model Interpretability in Machine Learning?](https://www.datarobot.com/wiki/interpretability/)
+- [Model Interpretability with SHAP](http://www.f1-predictor.com/model-interpretability-with-shap/)
+- [Interpreting bag of words models with SHAP](https://sararobinson.dev/2019/04/23/interpret-bag-of-words-models-shap.html)
+- [Explain any machine learning model prediction - using SHAP](https://towardsdatascience.com/how-to-explain-any-machine-learning-model-prediction-30654b0c1c8)
+- [Explain ML Models notebooks](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/explain-model)
+- [How to explain the prediction of a ML model](https://lilianweng.github.io/lil-log/2017/08/01/how-to-explain-the-prediction-of-a-machine-learning-model.html)
+- [Explaining complex machine learning models with LIME](https://datascienceplus.com/explaining-complex-machine-learning-models-with-lime/)
+- Hermeneutic Investigations: ML Interpreation - why?: [Video](https://www.youtube.com/watch?v=pmdYlahqA_g) | [Slides](https://github.com/daplantagenet/iml.github.io/blob/master/Hermeneutic%20Investigations.pdf) by [Dean Allsopp](http://github.com/daplantagenet)
+- [Explaining Explanations: An Overview ofInterpretability of Machine Learning](https://arxiv.org/pdf/1806.00069.pdf)
+- [Explaining Black-Box Machine Learning Models](https://shirinsplayground.netlify.com/2018/07/explaining_ml_models_code_caret_iml/)
+- [Interpretable Machine Learning](https://christophm.github.io/interpretable-ml-book/)
+- [R Machine Learning Projects by Dr. Sunil Kumar Chinnamgari: Model interpretability](https://www.oreilly.com/library/view/r-machine-learning/9781789807943/dcd398be-3488-423c-942c-69d1eac253f5.xhtml)
+- [Hands-on Machine Learning with R: Interpretable Machine Learning](https://bradleyboehmke.github.io/HOML/iml.html)
+- Tree SHAP
+  - [Consistent Individualized Feature Attribution for Tree Ensembles ](https://arxiv.org/abs/1802.03888)
+  - [Consistent feature attribution for tree ensembles](https://arxiv.org/abs/1706.06060)
+- [Exact SHAP: A Unified Approach to Interpreting Model Predictions](https://arxiv.org/abs/1705.07874)
+- [Integrated Gradients: Axiomatic Attribution for Deep Networks](https://arxiv.org/abs/1703.01365) | [GitHub](https://github.com/ankurtaly/Integrated-Gradients)
+- [Know Data Science](https://www.linkedin.com/feed/update/urn:li:activity:6516283940658089984)
+- [Understand How to answer Why](https://www.linkedin.com/feed/update/urn:li:activity:6519055798948204544)
+- [Learning with Explanations](https://www.youtube.com/watch?v=m1GUhPgstvk) by [Tim Rocktäschel](https://rockt.github.io/)
+- Towards Explainable AI: [Slides](../presentations/data/03-meetup-uk-2019/Towards-Explainable-AI.pdf) | [Video](https://www.youtube.com/watch?v=0yFjSs-azM4) | [Book: A Concise Introduction to Machine Learning](https://www.amazon.co.uk/Concise-Introduction-Machine-Learning/dp/0815384106/ref=tmm_pap_swatch_0?_encoding=UTF8&qid=1566160069&sr=8-2) by [Anita Faul](https://www.linkedin.com/in/anita-faul-123750104/)
+- [Machine Learning Project End to End with Python Code (data science focussed)](https://www.youtube.com/watch?v=ekV9QO5KHUY&list=PLcQCwsZDEzFkP9WMe6xvLrd_ZNGqoXOQY&fbclid=IwAR1z7XBl762FLyo-gVvdBDU1iCVqz89K1yfmJS1cbC4rZyEfF-jO30ZsYeY)
+    - Python Project (Classification) : 
+      - Part A: https://www.youtube.com/watch?v=p0snNMCbvN4&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=8
+      - Part B: https://www.youtube.com/watch?v=j4IgXflsZtg&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=9
+      - Part C: https://www.youtube.com/watch?v=kHZmFVDm0QQ&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=10

--- a/data/model-analysis-interpretation-explainability.md
+++ b/data/model-analysis-interpretation-explainability.md
@@ -39,3 +39,15 @@
       - Part A: https://www.youtube.com/watch?v=p0snNMCbvN4&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=8
       - Part B: https://www.youtube.com/watch?v=j4IgXflsZtg&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=9
       - Part C: https://www.youtube.com/watch?v=kHZmFVDm0QQ&list=PLcQCwsZDEzFkQj3tOV2NDrjJ43iuNY5yC&index=10
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/notebooks.md
+++ b/data/notebooks.md
@@ -1,0 +1,28 @@
+# Notebooks
+
+- [Python Data Science Handbook on Azure git repo](https://notebooks.azure.com/jakevdp/projects/PythonDataScienceHandbook/tree/notebooks)
+- [Python for Data Analysis on Azure git repo](https://notebooks.azure.com/wesm/projects/python-for-data-analysis)
+- [Python Data Science Handbook](https://jakevdp.github.io/PythonDataScienceHandbook/)
+- House prices
+    - [ML End-to-End Tutorial + Pandas notebook](../notebooks/data/DSfIOT_Machine_Learning_End_to_End_Tutorial.ipynb)
+    - [Regression example notebook](https://colab.research.google.com/drive/19uoDyGAxJ0zCwPT6cNb1xkYOfySNZChV)
+    - [Classification example notebook](https://colab.research.google.com/drive/1i-fOhU87wWrzgnTV0o54MQyHmRVJK0qt)
+    - Some explanations of the above Regression & Classification examples: [as a Notebook](https://drive.google.com/file/d/1vR9fOsWkCx0PuiCH0Eiz5FG1AAHuBHa8/view) | [as a PDF file](https://drive.google.com/file/d/1U3GkVgloBd5-w4qSj0KcyhtalhDF7pgC/view)
+- [Data science Python notebooks: Deep learning (TensorFlow, Theano, Caffe, Keras), scikit-learn, Kaggle, big data (Spark, Hadoop MapReduce, HDFS), matplotlib, pandas, NumPy, SciPy, Python essentials, AWS, and various command line tools](https://github.com/donnemartin/data-science-ipython-notebooks)
+- [Synthetic features and outliers notebook](https://colab.research.google.com/notebooks/mlcc/synthetic_features_and_outliers.ipynb?utm_source=mlcc&utm_campaign=colab-external&utm_medium=referral&utm_content=syntheticfeatures-colab&hl=en#scrollTo=jnKgkN5fHbGy)
+- Do we know our data...
+  - [Exploratory Data Analysis](../notebooks/jupyter/data/01_Exploratory_Data_Analysis_(Do_we_know_our_data).ipynb)
+  - [Data Preparation](../notebooks/jupyter/data/02_Data_Preparation_(Do_we_know_our_data).ipynb)
+  - [Feature Engineering](../notebooks/jupyter/data/03_Feature_Engineering_(Do_we_know_our_data).ipynb) 
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+---
+
+Back to [Data page (table of contents)](README.md)</br>
+Back to [main page (table of contents)](../README.md)

--- a/data/statistics.md
+++ b/data/statistics.md
@@ -24,7 +24,7 @@
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!
 
-Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
 
 ---
 

--- a/natural-language-processing/README.md
+++ b/natural-language-processing/README.md
@@ -122,7 +122,7 @@ NLP Java: [![NLP Java](https://img.shields.io/docker/pulls/neomatrix369/nlp-java
 - [An Introduction to Text Summarization using the TextRank Algorithm (with Python implementation)](https://www.analyticsvidhya.com/blog/2018/11/introduction-text-summarization-textrank-python/)
 - [Beyond bag of words: Using PyTextRank to find Phrases and Summarize text](https://medium.com/@aneesha/beyond-bag-of-words-using-pytextrank-to-find-phrases-and-summarize-text-f736fa3773c5)
 - [Build a simple text summarisation tool using NLTK](https://medium.com/@wilamelima/build-a-simple-text-summarisation-tool-using-nltk-ff0984fedb4f)
-- [Summarise Text with TFIDF in Python](https://medium.com/@shivangisareen/summarise-text-with-tfidf-in-python-bc7ca10d3284)
+- Summarise Text with TFIDF in Python: [Post 1/2](https://towardsdatascience.com/tfidf-for-piece-of-text-in-python-43feccaa74f8) | [Post 2/2](https://medium.com/@shivangisareen/summarise-text-with-tfidf-in-python-bc7ca10d3284)
 - [How to Make a Text Summarizer - Intro to Deep Learning #10 by Siraj Raval](https://www.youtube.com/watch?v=ogrJaOIuBx4)
 
 # Contributing


### PR DESCRIPTION
A number of split markdown files have been created from out of the data/README.md file:

- data/courses-books.md
- data/data-exploratory-analysis.md
- data/data-preparation.md
- data/databases.md
- data/datasets.md
- data/feature-engineering.md
- data/feature-selection.md
- data/frameworks-checklists.md
- data/model-analysis-interpretation-explainability.md
- data/notebooks.md
- data/statistics.md