### PR TITLE
Reformatting the indentation of the topics and sub-topics

### DIFF
--- a/Programming-in-Python.md
+++ b/Programming-in-Python.md
@@ -11,7 +11,7 @@
 - [Performance](#performance)
 - [Contributing](#contributing)
 
-### Basics / learning
+## Basics / learning
 
 - [Lists, Tuples, Dictionaries, Conditionals, Loops, etc...](https://lnkd.in/gWRbc3J)
 - [Data Structures & Algorithms](https://lnkd.in/gYKnJWN)
@@ -41,7 +41,8 @@
 - [30 seconds of python](https://github.com/30-seconds/30-seconds-of-python)
 
 ## Database
-##### Databases implemented in python
+
+### Databases implemented in python
 
 - [Pickle DB](https://pythonhosted.org/pickleDB/)
 - [Tinydb](https://github.com/msiemens/tinydb)
@@ -74,7 +75,7 @@
 * [multilint](https://github.com/adamchainz/multilint) - a wrapper around `flake8`, `isort` and `modernize`
 * [prospector](https://github.com/PyCQA/prospector) - a wrapper around `pylint`, `pep8`, `mccabe` and others
 
-## Cookie cutter: Python project templates
+### Cookie cutter: Python project templates
 
 - [For Python projects](https://cookiecutter.readthedocs.io/en/latest/readme.html#python)
 - [For Data Science projects](https://cookiecutter.readthedocs.io/en/latest/readme.html#data-science)

--- a/README-details.md
+++ b/README-details.md
@@ -2,15 +2,7 @@
 
 ### Artificial Intelligence
 
-- [Artificial intelligence (Wikipedia)](https://en.wikipedia.org/wiki/Artificial_intelligence)
-- [Artificial intelligence (Quora)](https://www.quora.com/topic/Artificial-Intelligence)
-- [History of Artificial Intelligence](https://en.wikipedia.org/wiki/History_of_artificial_intelligence)
-- [Artificial intelligence in video games](https://en.wikipedia.org/wiki/Artificial_intelligence_in_video_games)
-- [Scholarly articles for history of artificial intelligence](https://scholar.google.co.uk/scholar?q=history+of+artificial+intelligence&hl=en&as_sdt=0&as_vis=1&oi=scholart)
-- [Google AI Blog](https://ai.googleblog.com/) - the latest news from Google AI
-- [AI Experiments | Experiments with Google](https://experiments.withgoogle.com/ai) | [Experiments with Google](https://experiments.withgoogle.com/)
-- [People + AI Guidebook Logo](https://pair.withgoogle.com/)
-- [What is a tensor?](./data/what-is-a-tensor.jpg)
+See [Artificial Intelligence](artificial-intelligence.md)
 
 ### Automation
 
@@ -98,22 +90,8 @@ See [Notebooks](notebooks.md#notebooks)
 - Model Zoo: [Caffe docs](https://caffe2.ai/docs/zoo.html) | [Caffe](https://github.com/BVLC/caffe/wiki/Model-Zoo) | [MXNet](https://mxnet.incubator.apache.org/model_zoo/) | [DL4J](https://deeplearning4j.org/docs/latest/deeplearning4j-zoo-models) | [CoreNLP](https://stanfordnlp.github.io/CoreNLP/model-zoo.html)
 
 ### Articles, papers, code, data, courses
-  - [Papers, code, data by Yaz](https://github.com/yazdotai/paper-code-data)
-  - [Awesome AI Papers by Yaz (empty atm)](https://github.com/yazdotai/awesome-ai-papers)
-  - [Papers and code](https://paperswithcode.com)
-  - [Awesome DL papers](https://github.com/terryum/awesome-deep-learning-papers)
-  - [List of articles related to deep learning applied to music](https://github.com/ybayle/awesome-deep-learning-music)
-  - [Course material by Students of AI (Imperial College, London)](https://github.com/Students-for-AI/The-Academy-of-AI)
-  - [Data.world's open data - catalog your data, wake up your hidden data workforce, and build a data-driven culture—faster](https://data.world/)
-  - [Browse state-of-the-art](https://paperswithcode.com/sota)
-  - [ML/DL/Data Science resources (scattered across the page)](https://github.com/ayonroy2000/100DaysOfML_TelegramGroup/blob/master/Resources.md)
-  - [Papers by Google X](./papers/google-x/README.md#papers-by-members-of-google-and-google-x-aka-x-team)
-  - ML course by [Weights & Biases](https://wand.ai) ([WandB](https://wand.ai))
-    - [Code from the class](https://github.com/lukas/ml-class)
-    - [Setup Instructions](https://github.com/lukas/ml-class)
-    - [Slides](https://storage.googleapis.com/wandb/Bloomberg%20Class%201.pdf)
-    - [Building and Debugging CNNs](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE9193U0/bloomberg_class_2.pdf)
-    - [Introduction to ML](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE3Q7NN7/bloomberg_class_3.pdf)
+
+See [Articles, papers, code, data, courses](./articles-papers-code-data-courses.md)
 
 ### Presentations
   - [NLP presentations](./natural-language-processing/README.md#presentations)
@@ -131,15 +109,8 @@ See [Notebooks](notebooks.md#notebooks)
 See [Cheatsheets](cheatsheets.md#cheatsheets)
 
 ### Misc
-  - [Enterprise Data Analytics](https://www.dsta.gov.sg/docs/default-source/dsta-about/dh13201801_enterprise-data-analytics.pdf)
-  - [Data Analytics to Support Total WSH Management](https://www.osha-singapore.com/pdf/Goh-Yang-Miang--Data-Analytics-to-Support-Total-WSH-Management.pdf)
-  - [The Ultimate Learning Path to Become a Data Scientist and Master Machine Learning](https://www.analyticsvidhya.com/blog/2019/01/learning-path-data-scientist-machine-learning-2019/)
-  - [Learn Machine Learning from Top 50 Articles for the Past Year (v.2019)](https://medium.mybridge.co/learn-machine-learning-from-top-50-articles-for-the-past-year-v-2019-15842d0b82f6)
-  - [Feature-wise Transformations](https://distill.pub/2018/feature-wise-transformations/?utm_source=mybridge&utm_medium=blog&utm_campaign=read_more)
-  - [The 6 most useful Machine Learning projects of the past year (2018)](https://towardsdatascience.com/the-10-most-useful-machine-learning-projects-of-the-past-year-2018-5378bbd4919f)
-  - [The 25 Best Data Science and Machine Learning GitHub Repositories from 2018](https://www.analyticsvidhya.com/blog/2018/12/best-data-science-machine-learning-projects-github/?)
-  - [Computer Science (algorithms) resources by Chris Albon](https://chrisalbon.com/#computer_science)
-  - [AWS resources by Chris Albon](https://chrisalbon.com/#aws)
+ 
+ See [Misc](./misc.md)
 
 # Contributing
 

--- a/README-details.md
+++ b/README-details.md
@@ -32,40 +32,16 @@ See [Java](java-jvm.md#java_jvm)
 See [Julia, Python & R](julia-python-and-r.md#julia_python_and_r)
 
 ### JavaScript
-   - [What effect will AI have on programming languages?](https://medium.com/skills-matter/what-effect-will-ai-have-on-programming-languages-102bbb5f3024)
-   - [Tensorflow.js](https://js.tensorflow.org/) 
-   - Tensorflow Playground [1](https://playground.tensorflow.org/#activation=tanh&batchSize=10&dataset=circle&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=4,2&seed=0.87744&showTestData=false&discretize=false&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false) | [2](http://playground.tensorflow.org/#activation=sigmoid&regularization=L2&batchSize=10&dataset=circle&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=5,3&seed=0.84062&showTestData=false&discretize=true&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false&showTestData_hide=true&learningRate_hide=true&regularizationRate_hide=true&percTrainData_hide=true&numHiddenLayers_hide=false&discretize_hide=true&activation_hide=true&problem_hide=true&noise_hide=true&regularization_hide=true&dataset_hide=true&batchSize_hide=true&playButton_hide=false) | [3](http://playground.tensorflow.org/#activation=linear&regularization=L2&batchSize=10&dataset=gauss&regDataset=reg-plane&learningRate=0.0001&regularizationRate=0&noise=0&networkShape=&seed=0.27124&showTestData=false&discretize=true&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false&showTestData_hide=true&learningRate_hide=true&regularizationRate_hide=true&percTrainData_hide=true&numHiddenLayers_hide=true&discretize_hide=true&activation_hide=true&problem_hide=true&noise_hide=true&regularization_hide=true&dataset_hide=true&batchSize_hide=true&playButton_hide=false) | [4](http://playground.tensorflow.org/#activation=tanh&batchSize=10&dataset=spiral&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=4,2&seed=0.29208&showTestData=false&discretize=false&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false)
-   - [Bring deep learning into the browser &mdash; In Browser AI](https://inbrowser.ai/)
-   - [Run Keras models in the browser, with GPU support using WebGL](https://github.com/transcranial/keras-js)
-   - [Tensorflow.js: bringing ML into the browser](https://skillsmatter.com/skillscasts/11876-tensorflow-js-bringing-ml-into-the-browser)
-   - See [this link](https://github.com/josephmisiti/awesome-machine-learning#javascript) for more JavaScript related ML links
+
+See [JavaScript](./javascript.md)
 
 #### Visualisation
 
 See [Visualisation](README-details.md#visualisation-1)
 
 ### Mathematica & Wolfram Language
-  - General
-    - [Mathematica](https://www.wolfram.com/mathematica/)
-    - [Mathematica for home/hobbyist/individuals (pricing)](https://www.wolfram.com/mathematica/pricing/home-hobby-individuals.php)
-    - [Mathematica on Stackexchange](https://mathematica.stackexchange.com/)
-    - [Mathematica on Wikipedia](https://en.wikipedia.org/wiki/Wolfram_Mathematica)
-    - [Mathematica for prediction algorithms](https://mathematicaforprediction.wordpress.com/category/artificial-intelligence/)
-  - Stephen Wolfram
-    - [Stephen Wolfram: Knowledge Engine](https://lexfridman.com/stephen-wolfram/)
-    - [Stephen Wolfram: Artificial Intelligence blogs](https://blog.stephenwolfram.com/category/artificial-intelligence/?source=wordcloud)
-  - Wolfram
-    - [Wolfram Language Artificial Intelligence](https://blog.stephenwolfram.com/2015/05/wolfram-language-artificial-intelligence-the-image-identification-project/)
-    - [Wolfram Language & System](https://reference.wolfram.com/language/)
-    - [WolframResearch](https://github.com/WolframResearch)
-    - [Wolfram Community](https://community.wolfram.com/)
-    - [Open Source materials from Wolfram](https://wolfram.com/open-materials/)
-    - [Wolfram Client (python) available on pypi](https://pypi.org/project/wolframclient/)
-    - [External functions from users](https://resources.wolframcloud.com/FunctionRepository/)
-  - Neural Network & Machine Learning
-    - [Neural Network Repository](https://reference.wolfram.com/language/guide/NeuralNetworks.html) - a good overview page of Neural Network functions available in Mathematica / Wolfram Language
-    - [Neural Network tutorial](https://reference.wolfram.com/language/tutorial/NeuralNetworksIntroduction.html) - the main introduction on how to program with neural networks in Mathematica / Wolfram Language
-    - [Wolfram Neural Net Repository](https://resources.wolframcloud.com/NeuralNetRepository/) - The Wolfram Neural Net Repository is a public resource that hosts an expanding collection of trained and untrained neural network models, suitable for immediate evaluation, training, visualization, transfer learning and more
+ 
+See [Mathematica & Wolfram Language](./mathematica-wolfram-Language.md) 
 
 ### Mathematics, Statistics, Probability & Probabilistic programming
   

--- a/README-details.md
+++ b/README-details.md
@@ -1,3 +1,28 @@
+# Table of Contents
+
+- [General](#general)
+- [Artificial Intelligence](#artificial-intelligence)
+- [Automation](#automation)
+- [Ethics / altruistic motives](#ethics--altruistic-motives)
+- [Java](#java)
+- [Julia, Python & R](#julia-python--r)
+- [JavaScript](#javascript)
+- [Visualisation](#visualisation)
+- [Mathematica & Wolfram Language](#mathematica--wolfram-language)
+- [Mathematics, Statistics, Probability & Probabilistic programming](#mathematics-statistics-probability--probabilistic-programming)
+- [Data](#data)
+- [Graphs](#graphs)
+- [Examples](#examples)
+- [Notebooks](#notebooks)
+- [Models](#models)
+- [Articles, papers, code, data, courses](#articles-papers-code-data-courses)
+- [Presentations](#presentations)
+- [Best Practices](#best-practices)
+- [Cheatsheets](#cheatsheets)
+- [Misc](#misc)
+
+---
+
 ### General
 
 ### Artificial Intelligence
@@ -27,9 +52,9 @@ See [Julia, Python & R](julia-python-and-r.md#julia_python_and_r)
 
 See [JavaScript](./javascript.md)
 
-#### Visualisation
+### Visualisation
 
-See [Visualisation](README-details.md#visualisation-1)
+See [Visualisation](visualisation.md#visualisation)
 
 ### Mathematica & Wolfram Language
  
@@ -40,6 +65,7 @@ See [Mathematica & Wolfram Language](./mathematica-wolfram-Language.md)
 See [Mathematics, Statistics, Probability & Probabilistic programming](maths-stats-probability.md)
 
 ### Data
+
   - [Do we know our data...](./data/README.md#data)
     - [Data exploratory analysis](./data/README.md#data-exploratory-analysis)
     - [Data preparation](./data/README.md#data-preparation)
@@ -58,10 +84,6 @@ See [Mathematics, Statistics, Probability & Probabilistic programming](maths-sta
   - [Data Science resources (scattered across the page)](https://github.com/ayonroy2000/100DaysOfML_TelegramGroup/blob/master/Resources.md)
   - [Learn Data Science by bitgrit](https://github.com/bitgrit-official/learndatascience)
 
-### Visualisation
-
-See [Visualisation](visualisation.md#visualisation)
-
 ### Graphs
   - [A number of interesting links on Graph Networks by Yaz](https://github.com/yazdotai/graph-networks)
   - [Graph databases](./data/README.md#databases)
@@ -69,6 +91,7 @@ See [Visualisation](visualisation.md#visualisation)
   - [BCS APSG - 2019 02 14 How Graph Technology is Changing AI and ML at BCS London](https://www.youtube.com/watch?v=oMqP3ISPWBY)
 
 ### Examples
+
   - [Apache Zeppelin](./examples/apache-zeppelin/README.md)
   - [Better NLP](./examples/better-nlp/README.md)
   - [Cloud/DevOps/Infra](./examples/cloud-devops-infra)
@@ -94,6 +117,7 @@ See [Notebooks](notebooks.md#notebooks)
 See [Articles, papers, code, data, courses](./articles-papers-code-data-courses.md)
 
 ### Presentations
+
   - [NLP presentations](./natural-language-processing/README.md#presentations)
    - [Better NLP - presentations](./examples/better-nlp/presentations)
   - [Data presentations](./presentations/data/)
@@ -110,7 +134,7 @@ See [Cheatsheets](cheatsheets.md#cheatsheets)
 
 ### Misc
  
- See [Misc](./misc.md)
+See [Misc](./misc.md)
 
 # Contributing
 

--- a/articles-papers-code-data-courses.md
+++ b/articles-papers-code-data-courses.md
@@ -1,0 +1,31 @@
+# Articles, papers, code, data, courses
+
+  - [Papers, code, data by Yaz](https://github.com/yazdotai/paper-code-data)
+  - [Awesome AI Papers by Yaz (empty atm)](https://github.com/yazdotai/awesome-ai-papers)
+  - [Papers and code](https://paperswithcode.com)
+  - [Awesome DL papers](https://github.com/terryum/awesome-deep-learning-papers)
+  - [List of articles related to deep learning applied to music](https://github.com/ybayle/awesome-deep-learning-music)
+  - [Course material by Students of AI (Imperial College, London)](https://github.com/Students-for-AI/The-Academy-of-AI)
+  - [Data.world's open data - catalog your data, wake up your hidden data workforce, and build a data-driven culture—faster](https://data.world/)
+  - [Browse state-of-the-art](https://paperswithcode.com/sota)
+  - [ML/DL/Data Science resources (scattered across the page)](https://github.com/ayonroy2000/100DaysOfML_TelegramGroup/blob/master/Resources.md)
+  - [Papers by Google X](./papers/google-x/README.md#papers-by-members-of-google-and-google-x-aka-x-team)
+  - ML course by [Weights & Biases](https://wand.ai) ([WandB](https://wand.ai))
+    - [Code from the class](https://github.com/lukas/ml-class)
+    - [Setup Instructions](https://github.com/lukas/ml-class)
+    - [Slides](https://storage.googleapis.com/wandb/Bloomberg%20Class%201.pdf)
+    - [Building and Debugging CNNs](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE9193U0/bloomberg_class_2.pdf)
+    - [Introduction to ML](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE3Q7NN7/bloomberg_class_3.pdf)
+
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [details page (table of contents)](README-details.md#articles-papers-code-data-courses)<br>
+Back to [main page (table of contents)](README.md)

--- a/artificial-intelligence.md
+++ b/artificial-intelligence.md
@@ -1,0 +1,23 @@
+# Artificial intelligence
+
+- [Artificial intelligence (Wikipedia)](https://en.wikipedia.org/wiki/Artificial_intelligence)
+- [Artificial intelligence (Quora)](https://www.quora.com/topic/Artificial-Intelligence)
+- [History of Artificial Intelligence](https://en.wikipedia.org/wiki/History_of_artificial_intelligence)
+- [Artificial intelligence in video games](https://en.wikipedia.org/wiki/Artificial_intelligence_in_video_games)
+- [Scholarly articles for history of artificial intelligence](https://scholar.google.co.uk/scholar?q=history+of+artificial+intelligence&hl=en&as_sdt=0&as_vis=1&oi=scholart)
+- [Google AI Blog](https://ai.googleblog.com/) - the latest news from Google AI
+- [AI Experiments | Experiments with Google](https://experiments.withgoogle.com/ai) | [Experiments with Google](https://experiments.withgoogle.com/)
+- [People + AI Guidebook Logo](https://pair.withgoogle.com/)
+- [What is a tensor?](./data/what-is-a-tensor.jpg)
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [details page (table of contents)](README-details.md#artificial-intelligence)<br>
+Back to [main page (table of contents)](README.md)

--- a/competitions.md
+++ b/competitions.md
@@ -1,5 +1,7 @@
 # Competitions: AI, ML, DL, DS
 
+## General
+
 - [Kaggle competitions](https://www.kaggle.com/competitions)
     - [Closed DS Competition: CareerVillage](https://www.kaggle.com/c/data-science-for-good-careervillage)
     - [Closed DS Competition: City of Los Angeles](https://www.kaggle.com/c/data-science-for-good-city-of-los-angeles)

--- a/examples/JuPyteR/README.md
+++ b/examples/JuPyteR/README.md
@@ -4,7 +4,12 @@
 
 In theory, the below instructions should work for all operating systems i.e. Linux, MacOS and Windows. Although it has been only tested for Linux and MacOS.
 
-### Kernels
+## Blogs
+
+- [Running Jupyter notebooks on Oracle Cloud Infrastructure](https://medium.com/@neomatrix369/running-your-jupyter-notebooks-on-the-cloud-ed970326649f)
+
+## Kernels
+
 These are provided using via kernels, for e.g. the [IJava kernel](https://github.com/SpencerPark/IJava) when installed, provides Java language support in Jupyter notebooks. Take a look at the docs and examples provided on [https://github.com/SpencerPark/IJava](https://github.com/SpencerPark/IJava).
 
 Pre-requisite: only supports JDK versions 9 and higher

--- a/java-jvm.md
+++ b/java-jvm.md
@@ -4,7 +4,7 @@ NLP Java: [![NLP Java](https://img.shields.io/docker/pulls/neomatrix369/nlp-java
 
 Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/dataiku-dss.svg)](https://hub.docker.com/r/neomatrix369/dataiku-dss) | Grakn: [![Grakn](https://img.shields.io/docker/pulls/neomatrix369/grakn.svg)](https://hub.docker.com/r/neomatrix369/grakn) | Jupyter-Java: [![Jupyter-Java](https://img.shields.io/docker/pulls/neomatrix369/jupyter-java.svg)](https://hub.docker.com/r/neomatrix369/jupyter-java) | MLPMNist using DL4J: [![MLPMNist using DL4J](https://img.shields.io/docker/pulls/neomatrix369/dl4j-mnist-single-layer.svg)](https://hub.docker.com/r/neomatrix369/dl4j-mnist-single-layer) | Zeppelin: [![Zeppelin](https://img.shields.io/docker/pulls/neomatrix369/zeppelin.svg)](https://hub.docker.com/r/neomatrix369/zeppelin) 
 
-#### Business / General / Semi-technical
+## Business / General / Semi-technical
 
   - [Extract business value from DS](https://www.forbes.com/sites/oracle/2018/12/05/how-to-extract-business-value-from-data-science-its-all-about-the-teamwork/#6ad2f23a651c) ([Tweet](https://twitter.com/java/status/1070610044926930944))
   - [Why Java and the JVM Will Dominate the Future of Machine Learning, AI, and Big Data](https://www.youtube.com/watch?v=Ytja2JuVMlw&feature=youtu.be) ([Tweet](https://twitter.com/DeepNetts/status/1060684337962762240))
@@ -28,22 +28,23 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Oracle AI blog posts](https://blogs.oracle.com/ai/)
   - [H2O.ai Driverless on Oracle Cloude Infrastructure](https://blogs.oracle.com/cloud-infrastructure/h2oai-driverless-ai-cruises-on-oracle-cloud-infrastructure-gpus)
 
-#### Classifier / decision trees
+## Classifier / decision trees
 
   - [Email Spam Detector java Application with ApacheSpark](http://ramok.tech/2017/09/26/email-spam-classifier-java-application-with-spark/) ([Tweet](https://twitter.com/Klevis_Ramo/status/913067204094103552))
   - [Guide to Artificial Intelligence: Automating Decision-Making](https://dzone.com/guides/artificial-intelligence-automating-decision-making) ([Tweet](https://twitter.com/java/status/1029592519967830016))
 
-#### Correlated Cross Occurrence
+## Correlated Cross Occurrence
 
   - [Multi-domain predictive AI or how to make one thing predict another](https://developer.ibm.com/dwblog/2017/mahout-spark-correlated-cross-occurences/) ([Tweet](https://twitter.com/java/status/882222473886011393))
 
-#### Deep learning
+## Deep learning
 
   - [JFocus: Deep learning with Java](https://www.jfokus.se/jfokus17/preso/Deep-Learning-on-Java-tutorial.pdf) | [Video](https://www.youtube.com/watch?v=-hgAp470F-M) |([Tweet](https://twitter.com/juanantoniobm/status/832000819918733312))
   - [Understanding Machine Learning Algorithms with DL4J](https://skymind.ai/wiki/machine-learning-algorithms) ([Tweet](https://twitter.com/java/status/1077947895691673600))
   - [DL4J: Deep Learning for Java](https://deeplearning4j.org/) | [Docs/Guide](https://deeplearning4j.org/docs/latest/) | [Quickstart](https://deeplearning4j.org/docs/latest/deeplearning4j-quickstart) | [Tutorial](https://deeplearning4j.org/tutorials/setup) | [Roadmap for Beginners](https://deeplearning4j.org/docs/latest/deeplearning4j-beginners) | [DL4J Eclipse GitHub](https://github.com/eclipse/deeplearning4j) | DL4J Examples: [GitHub](https://github.com/deeplearning4j/dl4j-examples) o [Semantic site](https://semantive.com/deep-learning-examples/) o [Examples Tour](https://deeplearning4j.org/docs/latest/deeplearning4j-examples-tour)| [Setup Environment](https://www.tutorialkart.com/machine-learning/setup-environment-for-deep-learning-with-deeplearning4j/) | [Using DL4J](https://www.quora.com/How-do-I-use-deep-learning-in-Java) | Support: [gitter.im](https://gitter.im/deeplearning4j/deeplearning4j/) o [gitter guidelines](https://github.com/eclipse/deeplearning4j/blob/master/deeplearning4j/GITTER_GUIDELINES.md) o [GitHub Issues](https://github.com/deeplearning4j/deeplearning4j/issues) o [Stackoverflow](https://stackoverflow.com/search?tab=newest&q=deeplearning4j)
   - [DL Workshop at Devoxx UK 2018](https://github.com/davesnowdon/devoxxuk2018-dl-workshop) by [davesnowdon](https://github.com/davesnowdon)
   - [ND4J (Wikipedia)](https://en.wikipedia.org/wiki/ND4J_(software) | [ND4J in DL4J](https://deeplearning4j.org/docs/latest/nd4j-overview)
+  - [How to do Deep Learning for Java?](https://medium.com/@neomatrix369/how-to-do-deep-learning-for-java-on-the-valohai-platform-eec8ba9f71d8) | [Original post](https://blog.valohai.com/how-to-do-deep-learning-for-java-on-the-valohai-platform?from=3oxenia9mtr6)
   - [Free AI Training - Java-based deep-learning tools to analyze and train data, then send the resulting changes back to the server](https://www.youtube.com/watch?v=MXH_nn1dmsE) ([Tweet](https://twitter.com/java/status/1071422649501409280))
   - [Deep Learning Resources](https://skymind.com/wiki/deeplearning-research-papers)
   - [Data for Deep Learning](https://skymind.com/wiki/data-for-deep-learning)
@@ -51,25 +52,25 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Deep Learning Use cases](https://skymind.com/wiki/use-cases)
   - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)
 
-#### Reinforcement Learning 
+## Reinforcement Learning 
   - [Java implementation of Reinforcement Learning algorithms as described in the book "Reinforcement Learning: An Introduction" by Sutton](https://github.com/chen0040/java-reinforcement-learning)
 
-#### Genetic Algorithms
+## Genetic Algorithms
 
   - [Jenetics is an advanced Genetic Algorithm, respectively an Evolutionary Algorithm, library written in java](http://jenetics.io) ([Tweet](https://twitter.com/juanantoniobm/status/863871263118381056))
   - [JGAP is a Genetic Algorithms and Genetic Programming package written in Java](https://sourceforge.net/projects/jgap/)
   - [JaGa - Genetic Algorithms in Java on a Powerful Generic Pluggable Architecture](http://jaga.sourceforge.net/)
 
-#### Java projects / related technologies
+## Java projects / related technologies
 
   - [Project Panama and fast MachineLearning computation](https://www.youtube.com/watch?v=cfxBrYud9KM&feature=youtu.be&t=231) ([Tweet](https://twitter.com/java/status/1065266082557026304))
   - [GraalVM + Machine Learning](https://www.youtube.com/watch?v=6Q2TP-QO4SU) ([Tweet](https://twitter.com/DevoxxUA/status/1074680378357616640))
   - [Deploying Bespoke AI using fnproj - KADlytics by Miminal](https://blogs.oracle.com/startup/deploying-bespoke-ai-using-fn-project-kadlytics-by-miminal) ([Tweet]( https://twitter.com/java/status/1034474482751221761))
 
-#### Natural Language Processing (NLP)
+## Natural Language Processing (NLP)
   - See [Natural Language Processing (NLP)](natural-language-processing/README.md#Java-jvm)
 
-#### Neural Networks
+## Neural Networks
 
   - [Introduction to Neural Network Architectures](https://towardsdatascience.com/neural-network-architectures-156e5bad51ba) ([Tweet](https://twitter.com/java/status/953492326877356032))
   - [Neural Networks explained by MIT](https://www.csail.mit.edu/news/explained-neural-networks) ([Tweet](https://twitter.com/java/status/929216367361798144))
@@ -88,16 +89,16 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [predestination: Conway's Game of Life](https://github.com/SamirTalwar/predestination) by [Samir Talwar](https://github.com/SamirTalwar/) | [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)
   - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)
 
-#### Recommendation systems / Collaborative Filtering (CF)
+## Recommendation systems / Collaborative Filtering (CF)
   - [Tutorial on Collaborative Filtering (CF) in Java – a machine learning technique used by recommendation systems](https://www.baeldung.com/java-collaborative-filtering-recommendations) ([Tweet](https://twitter.com/java/status/985150431549632513))
   
-#### Data Science 
+## Data Science 
 
 - [Data Science for Java Developers](https://www.oreilly.com/library/view/data-science-with/9781491934104/ch01.html)
 - [Virgilio - Your new Mentor for Data Science E-Learning](https://github.com/clone95/Virgilio)
 - [Introduction to Data Science](https://www.youtube.com/watch?v=HEN6FBRuElE) | [Other Data Science Stuff related videos](https://www.youtube.com/channel/UCTe3bYxbzhstIRuIuGQz7UQ)
 
-#### Machine Learning
+## Machine Learning
 
 - [ML for Java Developers](https://www.itworld.com/article/3224505/application-development/machine-learning-for-java-developers.html)
 - [ML for Java Developers Course](http://numahub.com/courses/machine-learning-java-developers)
@@ -112,7 +113,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
 - See [Cloud/DevOps/Infra > Performance](./cloud-devops-infra/README.md#performance) - to find various ML performance benchmarking suites
 - Also see [Post model-creation analysis, ML interpretation/explainability](./data/README.md#post-model-creation-analysis-ml-interpretationexplainability)
 
-#### Tools & Libraries, Other Resources
+## Tools & Libraries, Other Resources
   - [Best AI tools and libraries](https://skymind.ai/wiki/automl-automated-machine-learning-ai) ([Tweet](https://twitter.com/java/status/1069459966740836352))
   - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)  ([Tweet](https://twitter.com/java/status/931070584896741377))
   - [Free AI Learning Resources For Beginners](https://www.analyticsindiamag.com/here-are-free-ai-learning-resources-for-beginners/) ([Twitter](https://twitter.com/java/status/1013776554868891648))
@@ -122,7 +123,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Teaching Java with Jupyter notebooks](https://blog.frankel.ch/teaching-java-jupyter-notebooks/)
   - [Efficient Java Matrix Library (EJML) is a linear algebra library for manipulating real/complex/dense/sparse matrices](http://ejml.org/wiki/index.php?title=Main_Page) | [Java Matrix Benchmark is a tool for evaluating Java linear algebra libraries for speed, stability, and memory usage](https://github.com/lessthanoptimal/Java-Matrix-Benchmark) by [Peter Abeles](https://github.com/lessthanoptimal)
 
-#### How-to / Deploy / DevOps / Serverless
+## How-to / Deploy / DevOps / Serverless
   - [Learn how to deploy and manage machine learning models](https://www.meetup.com/AI-for-Enterprise-Virtual-User-Group/events/254240417/) ([Tweet](https://t.co/4lcwns0lgo))
   - [How to prepare unstructured data for BI and data analytics AI and MachineLearning](https://www.infoq.com/presentations/ai-data-extraction) ([Tweet](https://twitter.com/java/status/869572617023488001))
   - Machine Learning Model Deployment Made Simple: [1](https://oracle.github.io/graphpipe/#/) [2](https://www.forbes.com/sites/oracle/2018/08/15/open-source-graphpipe-project-hints-at-next-wave-of-ai-expansion/#62a0c8c244ae) ([Tweet]( https://twitter.com/java/status/1038062329794052098))
@@ -131,7 +132,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Explore the use of modern Machine Learning and AI techniques in the context of serverless computing](https://medium.com/fnproject/serverless-and-recurrent-neural-networks-with-tensorflow-and-graphpipe-fc73785f1a16) ([Tweet](https://twitter.com/java/status/1043179793431384064))
   - [Disruptive Effects of Cloud Native Machine Learning Systems and Tools](https://www.datascience.com/blog/cloud-native-machine-learning-tools) ([Tweet](https://twitter.com/java/status/1077934809559707650))
 
-#### Misc
+## Misc
   - [Introduction to interactive Data Lake Queries](https://blogs.oracle.com/bigdata/interactive-data-lake-queries-at-scale) ([Tweet](https://twitter.com/java/status/989047609259151360))
   - [A Simple Introduction To Data Structures](https://towardsdatascience.com/a-simple-introduction-to-data-structures-part-one-linked-lists-efbb13e9ad33) ([Tweet](https://twitter.com/java/status/883093461842382849))
   - [Videos of various AI/ML related topics by AI Enterprise](https://www.youtube.com/channel/UC1PncmBLZMqlodEt7atfFuw)

--- a/javascript.md
+++ b/javascript.md
@@ -1,0 +1,21 @@
+# JavaScript
+
+   - [What effect will AI have on programming languages?](https://medium.com/skills-matter/what-effect-will-ai-have-on-programming-languages-102bbb5f3024)
+   - [Tensorflow.js](https://js.tensorflow.org/) 
+   - Tensorflow Playground [1](https://playground.tensorflow.org/#activation=tanh&batchSize=10&dataset=circle&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=4,2&seed=0.87744&showTestData=false&discretize=false&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false) | [2](http://playground.tensorflow.org/#activation=sigmoid&regularization=L2&batchSize=10&dataset=circle&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=5,3&seed=0.84062&showTestData=false&discretize=true&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false&showTestData_hide=true&learningRate_hide=true&regularizationRate_hide=true&percTrainData_hide=true&numHiddenLayers_hide=false&discretize_hide=true&activation_hide=true&problem_hide=true&noise_hide=true&regularization_hide=true&dataset_hide=true&batchSize_hide=true&playButton_hide=false) | [3](http://playground.tensorflow.org/#activation=linear&regularization=L2&batchSize=10&dataset=gauss&regDataset=reg-plane&learningRate=0.0001&regularizationRate=0&noise=0&networkShape=&seed=0.27124&showTestData=false&discretize=true&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false&showTestData_hide=true&learningRate_hide=true&regularizationRate_hide=true&percTrainData_hide=true&numHiddenLayers_hide=true&discretize_hide=true&activation_hide=true&problem_hide=true&noise_hide=true&regularization_hide=true&dataset_hide=true&batchSize_hide=true&playButton_hide=false) | [4](http://playground.tensorflow.org/#activation=tanh&batchSize=10&dataset=spiral&regDataset=reg-plane&learningRate=0.03&regularizationRate=0&noise=0&networkShape=4,2&seed=0.29208&showTestData=false&discretize=false&percTrainData=50&x=true&y=true&xTimesY=false&xSquared=false&ySquared=false&cosX=false&sinX=false&cosY=false&sinY=false&collectStats=false&problem=classification&initZero=false&hideText=false)
+   - [Bring deep learning into the browser &mdash; In Browser AI](https://inbrowser.ai/)
+   - [Run Keras models in the browser, with GPU support using WebGL](https://github.com/transcranial/keras-js)
+   - [Tensorflow.js: bringing ML into the browser](https://skillsmatter.com/skillscasts/11876-tensorflow-js-bringing-ml-into-the-browser)
+   - See [this link](https://github.com/josephmisiti/awesome-machine-learning#javascript) for more JavaScript related ML links
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [details page (table of contents)](README-details.md#javascript)<br>
+Back to [main page (table of contents)](README.md)

--- a/julia-python-and-r.md
+++ b/julia-python-and-r.md
@@ -1,6 +1,6 @@
 # Julia, Python and R
 
-  #### General
+  ## General
    - [Python Toolkit Used for Two Kaggle Top 10% Leaderboard Positions](https://www.reddit.com/r/deeplearning/comments/agx7qr/my_python_toolkit_that_i_used_for_two_kaggle_top/)
    - [Jeff Heaton's Kaggle boosting work](https://github.com/jeffheaton/jh-kaggle-util)
    - [An example on how-to install a Java kernel for JuPyteR notebooks (Graal enabled, where platform supports)](examples/JuPyteR/README.md)
@@ -16,52 +16,55 @@
    - [Book: Automate the boring stuff](https://automatetheboringstuff.com/)
    - [Book: How to Think Like a Computer Scientist: Interactive Edition](http://interactivepython.org/courselib/static/thinkcspy/index.html) | [How to Think Like a Computer Scientist - non-Interactive Edition](http://openbookproject.net/thinkcs/python/english2e/)
 
-  #### Generative Adversarial Network (GAN)
+  ## Generative Adversarial Network (GAN)
    - [A Beginner's Guide to Generative Adversarial Networks (GANs)](https://skymind.ai/wiki/generative-adversarial-network-gan)
    - [A tensorflow implementation of "Deep Convolutional Generative Adversarial Networks"](https://github.com/carpedm20/DCGAN-tensorflow)
    - [Collection of generative models, e.g. GAN, VAE in Pytorch and Tensorflow](https://github.com/wiseodd/generative-models)
    - [A probabilistic programming language in TensorFlow. Deep generative models, variational inference](https://github.com/blei-lab/edward)
    - [Defense-GAN: Protecting Classifiers Against Adversarial Attacks Using Generative Models](https://arxiv.org/pdf/1805.06605.pdf)
 
-  #### Genetic Algorithms
+  ## Genetic Algorithms
   - [Introduction to Genetic Algorithms & their application in data science](https://media.licdn.com/dms/document/C511FAQE99ZtwL7srQA/feedshare-document-pdf-analyzed/0?e=1570906800&v=beta&t=OiKdTPzo2ozpBzVl0N_5JPvzAoqsS2iie9cHNK4BXCg)
 
-  #### RNN
+  ## RNN
   - [The Unreasonable Effectiveness of Recurrent Neural Networks - Andrej Karpathy](http://karpathy.github.io/2015/05/21/rnn-effectiveness/)
   
-  #### Natural Language Processing (NLP)
+  ## Natural Language Processing (NLP)
   - See [Natural Language Processing (NLP)](natural-language-processing/README.md#natural-language-processing-nlp)
 
-  #### Computer Vision
-  ##### Motivation
+  ## Computer Vision
+  ### Motivation
   - [What is Computer vision?](https://machinelearningmastery.com/what-is-computer-vision/)
   - [Main topics to be covered (Basic outline)](https://www.pyimagesearch.com/start-here/)
   - [Introduction to CV](https://blog.algorithmia.com/introduction-to-computer-vision)
 
-  ##### Image Processing
+  ### Image Processing
   - [Digital Image Processing Basics](https://www.geeksforgeeks.org/digital-image-processing-basics/)
   - [Theory for Image Processing](http://web.ipac.caltech.edu/staff/fmasci/home/astro_refs/Digital_Image_Processing_2ndEd.pdf)
   - [Image and Video Processing course by Duke University, Coursera](https://www.coursera.org/learn/image-processing) (free, paid for certification)
 
-  ##### OpenCV and tutorials
+  ### OpenCV and tutorials
   - [Documentation and examples for each topic](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_table_of_contents_imgproc/py_table_of_contents_imgproc.html)
-  ##### Courses
+  
+  ### Courses
   - [Introduction to Computer Vision, Udacity, GeorgiaTech](https://www.udacity.com/course/introduction-to-computer-vision--ud810) (free, paid for certification)
   - [Stanford Computer Vision Lab : Teaching](http://vision.stanford.edu/teaching.html) - Contains publications other than courses (free)
   - [Introduction to CV, IBM](https://www.coursera.org/learn/introduction-computer-vision-watson-opencv) (free, paid for certification)
   - [Convolutional Neural Networks, Coursera](https://www.coursera.org/learn/convolutional-neural-networks) (free, paid for certification)
-  ##### Conferences to follow
+  
+  ### Conferences to follow
   - [CVPR](http://cvpr2019.thecvf.com/)
   - [ICCV](http://iccv2019.thecvf.com/) 
   - [ECCV](https://eccv2020.eu/)
   - [BMVC](https://bmvc2019.org/)
-  ##### Blogs
+  
+  ### Blogs
   - [PyImagesearch by Adrian Rosebrock](https://www.pyimagesearch.com/)
   - [Tombone's Computer Vision Blog](http://www.computervisionblog.com/)
   - [Get started in Computer Vision, Quora](https://www.quora.com/q/qqtmowjpnijmeujz/How-to-get-started-in-Computer-Vision-A-guide-for-the-CS-undergrad)
 
 
-  #### Data Science
+  ## Data Science
   
   - [Data science intro for math/phys background by Poitr Migdal](https://p.migdal.pl/2016/03/15/data-science-intro-for-math-phys-background.html)
   - [What I do or: science to data science by Poitr Migdal](https://p.migdal.pl/2015/12/14/sci-to-data-sci.html)
@@ -70,7 +73,7 @@
   - [David MacKay, Information Theory, Inference, and Learning Algorithms](http://www.inference.phy.cam.ac.uk/itila/book.html)
   - [Virgilio - Your new Mentor for Data Science E-Learning](https://github.com/clone95/Virgilio)
 
-  #### Machine Learning
+  ## Machine Learning
 
   - [A curated list of awesome Machine Learning frameworks, libraries and software](https://github.com/josephmisiti/awesome-machine-learning)
   - [Top ML repos](https://github.com/yazdotai/top-machine-learning)
@@ -107,7 +110,7 @@
   - See [Cloud/DevOps/Infra > Performance](./cloud-devops-infra/README.md#performance) - to find various ML performance benchmarking suites
   - Also see [Post model-creation analysis, ML interpretation/explainability](./data/README.md#post-model-creation-analysis-ml-interpretationexplainability)
 
-  #### Deep Learning
+  ## Deep Learning
    - [FREE! Deep learning book online - by Ian Goodfellow and Yoshua Bengio and Aaron Courville](http://www.deeplearningbook.org/)
    - [A curated list of awesome Deep Learning tutorials, projects and communities](https://github.com/josephmisiti/awesome-deep-learning)
    - [Deep learning library featuring a higher-level API for TensorFlow](https://github.com/tflearn/tflearn)
@@ -123,7 +126,7 @@
    - [Deep learning for 3D printing manufacturing](https://www.youtube.com/watch?v=jAQSM2dhDV4) by [Benjamin Schrauwen](https://www.linkedin.com/in/benjaminschrauwen)
    - [DL topics expanded by Chris Albon](https://chrisalbon.com/#deep_learning) - topics covered: Keras 
   
-  #### Reinforcement Learning
+  ## Reinforcement Learning
 
   - [Reinforcement learning resources curated resources](https://github.com/aikorea/awesome-rl)
   - [Gym: a toolkit for developing and comparing reinforcement learning algorithms](https://github.com/openai/gym)
@@ -146,7 +149,7 @@
   - Reinforcement Learning: An Introduction (Adaptive Computation and Machine Learning series) second edition Edition: [PDF book](http://incompleteideas.net/book/RLbook2018.pdf) by [Richard S. Sutton](http://incompleteideas.net/index.html) and [Andrew G. Barto](http://www-anw.cs.umass.edu/%7Ebarto/) | [Website and RL resources](http://incompleteideas.net/book/the-book-2nd.html)
   - [Teaching Artificial Agents to Understand Language by Modelling Reward](https://www.researchgate.net/publication/328437364_Teaching_Artificial_Agents_to_Understand_Language_by_Modelling_Reward) by [Edward Grefenstette](https://egrefen.github.io/) | [Video](https://www.youtube.com/watch?v=JCIIeDL9840)
 
-#### More...
+## More...
   - Julia: See [this link](https://github.com/josephmisiti/awesome-machine-learning#julia) for more Julia related ML links
   - Python: See [this link](https://github.com/josephmisiti/awesome-machine-learning#python) for more Python related ML links
   - R: See [this link](https://github.com/josephmisiti/awesome-machine-learning#r) for more R related ML links

--- a/mathematica-wolfram-Language.md
+++ b/mathematica-wolfram-Language.md
@@ -1,0 +1,33 @@
+# Mathematica & Wolfram Language
+ - General
+    - [Mathematica](https://www.wolfram.com/mathematica/)
+    - [Mathematica for home/hobbyist/individuals (pricing)](https://www.wolfram.com/mathematica/pricing/home-hobby-individuals.php)
+    - [Mathematica on Stackexchange](https://mathematica.stackexchange.com/)
+    - [Mathematica on Wikipedia](https://en.wikipedia.org/wiki/Wolfram_Mathematica)
+    - [Mathematica for prediction algorithms](https://mathematicaforprediction.wordpress.com/category/artificial-intelligence/)
+  - Stephen Wolfram
+    - [Stephen Wolfram: Knowledge Engine](https://lexfridman.com/stephen-wolfram/)
+    - [Stephen Wolfram: Artificial Intelligence blogs](https://blog.stephenwolfram.com/category/artificial-intelligence/?source=wordcloud)
+  - Wolfram
+    - [Wolfram Language Artificial Intelligence](https://blog.stephenwolfram.com/2015/05/wolfram-language-artificial-intelligence-the-image-identification-project/)
+    - [Wolfram Language & System](https://reference.wolfram.com/language/)
+    - [WolframResearch](https://github.com/WolframResearch)
+    - [Wolfram Community](https://community.wolfram.com/)
+    - [Open Source materials from Wolfram](https://wolfram.com/open-materials/)
+    - [Wolfram Client (python) available on pypi](https://pypi.org/project/wolframclient/)
+    - [External functions from users](https://resources.wolframcloud.com/FunctionRepository/)
+  - Neural Network & Machine Learning
+    - [Neural Network Repository](https://reference.wolfram.com/language/guide/NeuralNetworks.html) - a good overview page of Neural Network functions available in Mathematica / Wolfram Language
+    - [Neural Network tutorial](https://reference.wolfram.com/language/tutorial/NeuralNetworksIntroduction.html) - the main introduction on how to program with neural networks in Mathematica / Wolfram Language
+    - [Wolfram Neural Net Repository](https://resources.wolframcloud.com/NeuralNetRepository/) - The Wolfram Neural Net Repository is a public resource that hosts an expanding collection of trained and untrained neural network models, suitable for immediate evaluation, training, visualization, transfer learning and more
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [details page (table of contents)](README-details.md#mathematica-wolfram-language)<br>
+Back to [main page (table of contents)](README.md)

--- a/mathematica-wolfram-Language.md
+++ b/mathematica-wolfram-Language.md
@@ -29,5 +29,5 @@ Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have 
 
 ---
 
-Back to [details page (table of contents)](README-details.md#mathematica-wolfram-language)<br>
+Back to [details page (table of contents)](README-details.md#mathematica--wolfram-language)<br>
 Back to [main page (table of contents)](README.md)

--- a/misc.md
+++ b/misc.md
@@ -1,0 +1,24 @@
+# Misc
+
+ - [Enterprise Data Analytics](https://www.dsta.gov.sg/docs/default-source/dsta-about/dh13201801_enterprise-data-analytics.pdf)
+  - [Data Analytics to Support Total WSH Management](https://www.osha-singapore.com/pdf/Goh-Yang-Miang--Data-Analytics-to-Support-Total-WSH-Management.pdf)
+  - [The Ultimate Learning Path to Become a Data Scientist and Master Machine Learning](https://www.analyticsvidhya.com/blog/2019/01/learning-path-data-scientist-machine-learning-2019/)
+  - [Learn Machine Learning from Top 50 Articles for the Past Year (v.2019)](https://medium.mybridge.co/learn-machine-learning-from-top-50-articles-for-the-past-year-v-2019-15842d0b82f6)
+  - [Feature-wise Transformations](https://distill.pub/2018/feature-wise-transformations/?utm_source=mybridge&utm_medium=blog&utm_campaign=read_more)
+  - [The 6 most useful Machine Learning projects of the past year (2018)](https://towardsdatascience.com/the-10-most-useful-machine-learning-projects-of-the-past-year-2018-5378bbd4919f)
+  - [The 25 Best Data Science and Machine Learning GitHub Repositories from 2018](https://www.analyticsvidhya.com/blog/2018/12/best-data-science-machine-learning-projects-github/?)
+  - [Computer Science (algorithms) resources by Chris Albon](https://chrisalbon.com/#computer_science)
+  - [AWS resources by Chris Albon](https://chrisalbon.com/#aws)
+
+
+
+# Contributing
+
+Contributions are very welcome, please share back with the wider community (and get credited for it)!
+
+Please have a look at the [CONTRIBUTING](CONTRIBUTING.md) guidelines, also have a read about our [licensing](LICENSE.md) policy.
+
+---
+
+Back to [details page (table of contents)](README-details.md#misc)<br>
+Back to [main page (table of contents)](README.md)


### PR DESCRIPTION
Splitting README-details.md into smaller markdown files and reformatting them:

- Programming-in-Python.md
- README-details.md
- articles-papers-code-data-courses.md
- artificial-intelligence.md
- competitions.md
- examples/JuPyteR/README.md
- java-jvm.md
- javascript.md
- julia-python-and-r.md
- mathematica-wolfram-Language.md
- misc.md

Adding a ToC to README-details