### PR TITLE
Adding ToC to a number of markdown pages

### DIFF
--- a/README-details.md
+++ b/README-details.md
@@ -20,6 +20,7 @@
 - [Best Practices](#best-practices)
 - [Cheatsheets](#cheatsheets)
 - [Misc](#misc)
+- [Contributing](#contributing)
 
 ---
 

--- a/articles-papers-code-data-courses.md
+++ b/articles-papers-code-data-courses.md
@@ -17,8 +17,6 @@
     - [Building and Debugging CNNs](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE9193U0/bloomberg_class_2.pdf)
     - [Introduction to ML](https://wb-ml.slack.com/files/UN2SL6G7Q/FNE3Q7NN7/bloomberg_class_3.pdf)
 
-
-
 # Contributing
 
 Contributions are very welcome, please share back with the wider community (and get credited for it)!

--- a/cloud-devops-infra/README.md
+++ b/cloud-devops-infra/README.md
@@ -1,24 +1,37 @@
-### Cloud, DevOps, Infra
+# Cloud, DevOps, Infra
 
-#### System / Infra
+- [System / Infra](#system--infra)
+- [Compute & Storage](#compute--storage)
+- [Grid computing / Super computing](#grid-computing--super-computing)
+- [Cloud services](#cloud-services)
+- [Tools](#tools)
+- [CPU](#cpu)
+- [FPGA](#fpga)
+- [GPU](#gpu)
+- [TPU](#tpu)
+- [IPU](#ipu)
+- [Performance](#performance)
+- [Contributing](#contributing)
+
+## System / Infra
 
   - [serveo.net](http://serveo.net) - Serveo is an SSH server just for remote port forwarding. When a user connects to Serveo, they get a public URL that anybody can use to connect to their localhost server. See link for other SSH and related alternatives, useful to be able to serve resources across devices i.e. access GPU or other hardware accelerators from another device remotely. | [How to forward my local port to public using Serveo?](https://medium.com/@osanda.deshan/how-to-forward-my-local-port-to-public-using-serveo-4979f352a3bf) | [Serveo on GitHub](https://github.com/milio48/serveo)
   - [Inlets](https://github.com/alexellis/inlets) by [Alex Ellis](https://github.com/alexellis) | [Get started](https://github.com/alexellis/inlets#get-started) | [Video](https://www.youtube.com/watch?v=jrAqqe8N3q4&feature=youtu.be)
 
-#### Compute & Storage
+## Compute & Storage
   
   - [Cray Computers](https://www.cray.com/ai) | [Artificial Intelligence](https://www.cray.com/solutions/artificial-intelligence) | [Accel AI](https://www.cray.com/solutions/artificial-intelligence/cray-accel-ai) | [Cryp-em](https://www.cray.com/solutions/cryo-em) | [Autonomous Vehicles](https://www.cray.com/solutions/autonomous-vehicles) | [Geospatial AI](https://www.cray.com/solutions/geospatial-ai)
   - [GraphCore's IPU](README.md#ipu)
   - [Lambda Labs](https://lambdalabs.com/)
   - NGD Systems: [Technology](https://www.ngdsystems.com/technology) | [Solutions](https://www.ngdsystems.com/solutions) - High Compute Storage, Scalable Computational Storage | [NGD Systems: Ensuring AI Advancement with Intelligent Storage](https://www.insightssuccess.com/ngd-systems-ensuring-ai-advancement-with-intelligent-storage/)
 
-### Grid computing / Super computing
+## Grid computing / Super computing
 
 - Grid Engine: [wikipedia](https://en.wikipedia.org/wiki/Univa_Grid_Engine) | [Univa website](http://www.univa.com/products/) | [Datasheet](http://www.univa.com/resources/files/univa-unisight-datasheet.pdf)
 - [BOINC](https://boinc.berkeley.edu/) - High-Throughput Computing with BOINC | [Tech Docs](https://boinc.berkeley.edu/trac/wiki/ProjectMain) | [Download BOINC](https://boinc.berkeley.edu/download.php) | [GitHub](https://github.com/BOINC/boinc)
 - [Cray Computers](https://www.cray.com/solutions/supercomputing-as-a-service) - Supercomputing as a Service
 
-#### Cloud services
+## Cloud services
 
   - [vast.ai](about-vast.ai.md) - GPU Sharing Economy. One simple interface to find the best cloud GPU rentals. Reduce cloud compute costs by 3X to 5X
   - [paperspace](https://www.paperspace.com/) - The first cloud built for the future. Powering next-generation applications and cloud ML/AI pipelines. Paperspace is built to scale with your team - pay as you go option for individuals.
@@ -28,7 +41,8 @@
   - [Verne Global: HPC Cloud](https://verneglobal.com/solutions/hpc-cloud) | [NVidia DGX Ready](https://verneglobal.com/dgxready)
   - [Weights and Biases](wandb.ai) | [Learn more about WandB](../data/about-Weights-and-Biases.md)
 
-#### Tools
+## Tools
+
   - [snakemake](https://snakemake.readthedocs.io/en/stable/) - The Snakemake workflow management system is a tool to create reproducible and scalable data analyses. [Slides](https://slides.com/johanneskoester/snakemake-talk-40min#) | [PyPi](https://pypi.org/project/snakemake/)
   - [plz](http://github.com/prodo-ai/plz) - Plz (pronounced "please") runs your jobs storing code, input, outputs and results so that they can be queried programmatically.
   - [valohai](https://www.valohai.com/) | [docs](https://docs.valohai.com/) | [blogs](https://blogs.valohai.com) | [GitHub](https://github.com/valohai) | [Videos](https://www.youtube.com/channel/UCiR8Fpv6jRNphaZ99PnIuFg) | [Showcase](https://valohai.com/showcase/) | [Slack](http://community-slack.valohai.com/) - Valohai is a machine learning platform. It runs your experiments in the cloud, tracks your experiment history and streamlines data science workflows. DEEP LEARNING MANAGEMENT PLATFORM. Machine Orchestration, Version Control and Pipeline Management for Deep Learning.
@@ -41,7 +55,8 @@
   - [cortex](cortex.dev) - Machine learning deployment platform: Deploy machine learning models to production
   - [See also: Data > Programs and Tools](../data/programs-and-tools.md#programs-and-tools)
 
-#### CPU
+## CPU
+
   - Probing the CPU (Linux/MacOS)
       - [libcpuid](http://libcpuid.sourceforge.net/index.html)
       + Zero overhead performance capturing: use `/proc/interrupts` and `/proc/softirqs`
@@ -60,24 +75,28 @@
  
  _Thanks to the great minds on the [mechanical sympathy](https://groups.google.com/forum/#!forum/mechanical-sympathy) mailing list for their responses to my queries on CPU probing._
 
-#### FPGA
+## FPGA
 
   - [Intel AI Developer Program - Deep Learning Inference With Intel® FPGAs](https://software.intel.com/en-us/ai/courses/deep-learning-inference-fpga)
   - [Using FPGAs for Datacenter Acceleration](https://event.on24.com/eventRegistration/EventLobbyServlet?target=lobby20.jsp&eventid=2033432&sessionid=1&eventuserid=246511756&key=8678836B54A84876D7338D7BF7F87B88) | [Windows AI](https://docs.microsoft.com/en-us/windows/ai/) | [Intel® Distribution of OpenVINO™ Toolkit: Develop Multiplatform Computer Vision Solutions](https://software.intel.com/en-us/openvino-toolkit)
 
-#### GPU
+## GPU
+
   - [Know your GPU](https://gist.github.com/neomatrix369/256913dcf77cdbb5855dd2d7f5d81b84)
   - [GPU Server 1 of 2](./gpus/GPU-Server-side-1-of-2.jpg) | [GPU Server 2 of 2](./gpus/GPU-Server-side-2-of-2.jpg) | [Applications of GPU servers](./gpus/Applications-of-GPU-Server.jpg) - [checkout the manufacturers](http://manli.com/en/)
   - [Embedded Vision Solutions for NVIDIA Jetson Series](https://www.avermedia.com/professional/category/nvidia_jetson_solutions) | [Embedded Vision Family Brochure](http://storage.avermedia.com/web_release_www/Solutions/Embedded_Vision_Solutions_brochure_20190429.pdf)
   - Avermedia Box PC & Carrier (works with NVidia Jetson): [1](./gpus/Avermedia-Box-PC-and-Carrier-1-of-2-works-with-NVidia-Jetson.jpg) | [2](./gpus/Avermedia-Box-PC-and-Carrier-2-of-2-works-with-NVidia-Jetson.jpg)
 
-#### TPU
+## TPU
+
   - [How to harness the Powers of the Cloud TPU](https://medium.com/bitgrit-data-science-publication/how-to-harness-the-powers-of-the-cloud-tpu-3939dc363d9f)
 
-#### IPU
+## IPU
+
   - [GraphCore](http://graphcore.ai) | Videos: [Simon Knowles - More complex models and more powerful machines](https://www.youtube.com/watch?v=dLvkF_TmyAc&feature=youtu.be) | [Graphcore tech Concept](https://youtu.be/cSXbhEsUUGo?t=916) | [A new kind of hardware designed for machine intelligence - GraphCore Presentations](http://www.bristol.bcs.org.uk/2017/graphcore.pdf) | [V‍ID‌EO‌‍: SCA‌LING‌‍ THRO‌UG‍HP‌‍U‌T P‍R‌O‍C‍ESSO‌‍RS FO‌‍R‍ MAC‌HINE INTELLIG‌ENC‌‍E](https://www.graphcore.ai/posts/video-scaling-throughput-processors-for-machine-intelligence)
 
-#### Performance
+## Performance
+
   - [MLPerf](https://mlperf.org/) - Fair and useful benchmarks for measuring training and inference performance of ML hardware, software, and services.
   - [MLPerf introduces machine learning inference benchmark suite...](https://venturebeat.com/2019/06/24/mlperf-introduces-machine-learning-inference-benchmark-suite/)
   - [ONE DEEP LEARNING BENCHMARK TO RULE THEM ALL](https://www.nextplatform.com/2018/08/30/one-deep-learning-benchmark-to-rule-them-all/)

--- a/data/README.md
+++ b/data/README.md
@@ -6,8 +6,6 @@ The question to ask ourselves: _Do we know our data...?_
 
 ---
 
-### Table of contents
-
 - [Ethics / altruistic motives](./README.md#ethics--altruistic-motives)
 - [Datasets and sources of raw data](./README.md#datasets-and-sources-of-raw-data)
 - [Data Exploratory Analysis](./README.md#data-exploratory-analysis)

--- a/java-jvm.md
+++ b/java-jvm.md
@@ -4,6 +4,29 @@ NLP Java: [![NLP Java](https://img.shields.io/docker/pulls/neomatrix369/nlp-java
 
 Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/dataiku-dss.svg)](https://hub.docker.com/r/neomatrix369/dataiku-dss) | Grakn: [![Grakn](https://img.shields.io/docker/pulls/neomatrix369/grakn.svg)](https://hub.docker.com/r/neomatrix369/grakn) | Jupyter-Java: [![Jupyter-Java](https://img.shields.io/docker/pulls/neomatrix369/jupyter-java.svg)](https://hub.docker.com/r/neomatrix369/jupyter-java) | MLPMNist using DL4J: [![MLPMNist using DL4J](https://img.shields.io/docker/pulls/neomatrix369/dl4j-mnist-single-layer.svg)](https://hub.docker.com/r/neomatrix369/dl4j-mnist-single-layer) | Zeppelin: [![Zeppelin](https://img.shields.io/docker/pulls/neomatrix369/zeppelin.svg)](https://hub.docker.com/r/neomatrix369/zeppelin) 
 
+---
+
+- [Business / General / Semi-technical](#business--general--semi-technical)
+- [Classifier / decision trees](#classifier--decision-trees)
+- [Correlated Cross Occurrence](#correlated-cross-occurrence)
+- [Genetic Algorithms](#genetic-algorithms)
+- [Java projects / related technologies](#java-projects--related-technologies)
+- [Natural Language Processing (NLP)](#natural-language-processing-nlp)
+- [Neural Networks](#neural-networks)
+- [Recommendation systems / Collaborative Filtering (CF)](#recommendation-systems--collaborative-filtering-cf)
+- [Data Science](#data-science)
+- [Machine Learning](machine-learning)
+  - [Deep learning](#deep-learning)
+    - [Reinforcement Learning](#reinforcement-learning)
+- [Tools & Libraries, Other Resources](#tools--libraries-other-resources)
+- [How-to / Deploy / DevOps / Serverless](#how-to--deploy--devops--serverless)
+- [Misc](#misc)
+- [Clojure](#clojure)
+- [Scala](#scala)
+- [Contributing](#contributing)
+
+---
+
 ## Business / General / Semi-technical
 
   - [Extract business value from DS](https://www.forbes.com/sites/oracle/2018/12/05/how-to-extract-business-value-from-data-science-its-all-about-the-teamwork/#6ad2f23a651c) ([Tweet](https://twitter.com/java/status/1070610044926930944))
@@ -37,24 +60,6 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
 
   - [Multi-domain predictive AI or how to make one thing predict another](https://developer.ibm.com/dwblog/2017/mahout-spark-correlated-cross-occurences/) ([Tweet](https://twitter.com/java/status/882222473886011393))
 
-## Deep learning
-
-  - [JFocus: Deep learning with Java](https://www.jfokus.se/jfokus17/preso/Deep-Learning-on-Java-tutorial.pdf) | [Video](https://www.youtube.com/watch?v=-hgAp470F-M) |([Tweet](https://twitter.com/juanantoniobm/status/832000819918733312))
-  - [Understanding Machine Learning Algorithms with DL4J](https://skymind.ai/wiki/machine-learning-algorithms) ([Tweet](https://twitter.com/java/status/1077947895691673600))
-  - [DL4J: Deep Learning for Java](https://deeplearning4j.org/) | [Docs/Guide](https://deeplearning4j.org/docs/latest/) | [Quickstart](https://deeplearning4j.org/docs/latest/deeplearning4j-quickstart) | [Tutorial](https://deeplearning4j.org/tutorials/setup) | [Roadmap for Beginners](https://deeplearning4j.org/docs/latest/deeplearning4j-beginners) | [DL4J Eclipse GitHub](https://github.com/eclipse/deeplearning4j) | DL4J Examples: [GitHub](https://github.com/deeplearning4j/dl4j-examples) o [Semantic site](https://semantive.com/deep-learning-examples/) o [Examples Tour](https://deeplearning4j.org/docs/latest/deeplearning4j-examples-tour)| [Setup Environment](https://www.tutorialkart.com/machine-learning/setup-environment-for-deep-learning-with-deeplearning4j/) | [Using DL4J](https://www.quora.com/How-do-I-use-deep-learning-in-Java) | Support: [gitter.im](https://gitter.im/deeplearning4j/deeplearning4j/) o [gitter guidelines](https://github.com/eclipse/deeplearning4j/blob/master/deeplearning4j/GITTER_GUIDELINES.md) o [GitHub Issues](https://github.com/deeplearning4j/deeplearning4j/issues) o [Stackoverflow](https://stackoverflow.com/search?tab=newest&q=deeplearning4j)
-  - [DL Workshop at Devoxx UK 2018](https://github.com/davesnowdon/devoxxuk2018-dl-workshop) by [davesnowdon](https://github.com/davesnowdon)
-  - [ND4J (Wikipedia)](https://en.wikipedia.org/wiki/ND4J_(software) | [ND4J in DL4J](https://deeplearning4j.org/docs/latest/nd4j-overview)
-  - [How to do Deep Learning for Java?](https://medium.com/@neomatrix369/how-to-do-deep-learning-for-java-on-the-valohai-platform-eec8ba9f71d8) | [Original post](https://blog.valohai.com/how-to-do-deep-learning-for-java-on-the-valohai-platform?from=3oxenia9mtr6)
-  - [Free AI Training - Java-based deep-learning tools to analyze and train data, then send the resulting changes back to the server](https://www.youtube.com/watch?v=MXH_nn1dmsE) ([Tweet](https://twitter.com/java/status/1071422649501409280))
-  - [Deep Learning Resources](https://skymind.com/wiki/deeplearning-research-papers)
-  - [Data for Deep Learning](https://skymind.com/wiki/data-for-deep-learning)
-  - [Questions when applying Deep Learning](https://skymind.com/wiki/questions-when-applying-deep-learning)
-  - [Deep Learning Use cases](https://skymind.com/wiki/use-cases)
-  - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)
-
-## Reinforcement Learning 
-  - [Java implementation of Reinforcement Learning algorithms as described in the book "Reinforcement Learning: An Introduction" by Sutton](https://github.com/chen0040/java-reinforcement-learning)
-
 ## Genetic Algorithms
 
   - [Jenetics is an advanced Genetic Algorithm, respectively an Evolutionary Algorithm, library written in java](http://jenetics.io) ([Tweet](https://twitter.com/juanantoniobm/status/863871263118381056))
@@ -68,6 +73,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Deploying Bespoke AI using fnproj - KADlytics by Miminal](https://blogs.oracle.com/startup/deploying-bespoke-ai-using-fn-project-kadlytics-by-miminal) ([Tweet]( https://twitter.com/java/status/1034474482751221761))
 
 ## Natural Language Processing (NLP)
+
   - See [Natural Language Processing (NLP)](natural-language-processing/README.md#Java-jvm)
 
 ## Neural Networks
@@ -90,6 +96,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)
 
 ## Recommendation systems / Collaborative Filtering (CF)
+
   - [Tutorial on Collaborative Filtering (CF) in Java – a machine learning technique used by recommendation systems](https://www.baeldung.com/java-collaborative-filtering-recommendations) ([Tweet](https://twitter.com/java/status/985150431549632513))
   
 ## Data Science 
@@ -113,7 +120,27 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
 - See [Cloud/DevOps/Infra > Performance](./cloud-devops-infra/README.md#performance) - to find various ML performance benchmarking suites
 - Also see [Post model-creation analysis, ML interpretation/explainability](./data/README.md#post-model-creation-analysis-ml-interpretationexplainability)
 
+### Deep learning
+
+  - [JFocus: Deep learning with Java](https://www.jfokus.se/jfokus17/preso/Deep-Learning-on-Java-tutorial.pdf) | [Video](https://www.youtube.com/watch?v=-hgAp470F-M) |([Tweet](https://twitter.com/juanantoniobm/status/832000819918733312))
+  - [Understanding Machine Learning Algorithms with DL4J](https://skymind.ai/wiki/machine-learning-algorithms) ([Tweet](https://twitter.com/java/status/1077947895691673600))
+  - [DL4J: Deep Learning for Java](https://deeplearning4j.org/) | [Docs/Guide](https://deeplearning4j.org/docs/latest/) | [Quickstart](https://deeplearning4j.org/docs/latest/deeplearning4j-quickstart) | [Tutorial](https://deeplearning4j.org/tutorials/setup) | [Roadmap for Beginners](https://deeplearning4j.org/docs/latest/deeplearning4j-beginners) | [DL4J Eclipse GitHub](https://github.com/eclipse/deeplearning4j) | DL4J Examples: [GitHub](https://github.com/deeplearning4j/dl4j-examples) o [Semantic site](https://semantive.com/deep-learning-examples/) o [Examples Tour](https://deeplearning4j.org/docs/latest/deeplearning4j-examples-tour)| [Setup Environment](https://www.tutorialkart.com/machine-learning/setup-environment-for-deep-learning-with-deeplearning4j/) | [Using DL4J](https://www.quora.com/How-do-I-use-deep-learning-in-Java) | Support: [gitter.im](https://gitter.im/deeplearning4j/deeplearning4j/) o [gitter guidelines](https://github.com/eclipse/deeplearning4j/blob/master/deeplearning4j/GITTER_GUIDELINES.md) o [GitHub Issues](https://github.com/deeplearning4j/deeplearning4j/issues) o [Stackoverflow](https://stackoverflow.com/search?tab=newest&q=deeplearning4j)
+  - [DL Workshop at Devoxx UK 2018](https://github.com/davesnowdon/devoxxuk2018-dl-workshop) by [davesnowdon](https://github.com/davesnowdon)
+  - [ND4J (Wikipedia)](https://en.wikipedia.org/wiki/ND4J_(software) | [ND4J in DL4J](https://deeplearning4j.org/docs/latest/nd4j-overview)
+  - [How to do Deep Learning for Java?](https://medium.com/@neomatrix369/how-to-do-deep-learning-for-java-on-the-valohai-platform-eec8ba9f71d8) | [Original post](https://blog.valohai.com/how-to-do-deep-learning-for-java-on-the-valohai-platform?from=3oxenia9mtr6)
+  - [Free AI Training - Java-based deep-learning tools to analyze and train data, then send the resulting changes back to the server](https://www.youtube.com/watch?v=MXH_nn1dmsE) ([Tweet](https://twitter.com/java/status/1071422649501409280))
+  - [Deep Learning Resources](https://skymind.com/wiki/deeplearning-research-papers)
+  - [Data for Deep Learning](https://skymind.com/wiki/data-for-deep-learning)
+  - [Questions when applying Deep Learning](https://skymind.com/wiki/questions-when-applying-deep-learning)
+  - [Deep Learning Use cases](https://skymind.com/wiki/use-cases)
+  - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)
+
+#### Reinforcement Learning
+
+  - [Java implementation of Reinforcement Learning algorithms as described in the book "Reinforcement Learning: An Introduction" by Sutton](https://github.com/chen0040/java-reinforcement-learning)
+
 ## Tools & Libraries, Other Resources
+
   - [Best AI tools and libraries](https://skymind.ai/wiki/automl-automated-machine-learning-ai) ([Tweet](https://twitter.com/java/status/1069459966740836352))
   - [Overview of AI Libraries in Java](https://www.baeldung.com/java-ai)  ([Tweet](https://twitter.com/java/status/931070584896741377))
   - [Free AI Learning Resources For Beginners](https://www.analyticsindiamag.com/here-are-free-ai-learning-resources-for-beginners/) ([Twitter](https://twitter.com/java/status/1013776554868891648))
@@ -124,6 +151,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Efficient Java Matrix Library (EJML) is a linear algebra library for manipulating real/complex/dense/sparse matrices](http://ejml.org/wiki/index.php?title=Main_Page) | [Java Matrix Benchmark is a tool for evaluating Java linear algebra libraries for speed, stability, and memory usage](https://github.com/lessthanoptimal/Java-Matrix-Benchmark) by [Peter Abeles](https://github.com/lessthanoptimal)
 
 ## How-to / Deploy / DevOps / Serverless
+
   - [Learn how to deploy and manage machine learning models](https://www.meetup.com/AI-for-Enterprise-Virtual-User-Group/events/254240417/) ([Tweet](https://t.co/4lcwns0lgo))
   - [How to prepare unstructured data for BI and data analytics AI and MachineLearning](https://www.infoq.com/presentations/ai-data-extraction) ([Tweet](https://twitter.com/java/status/869572617023488001))
   - Machine Learning Model Deployment Made Simple: [1](https://oracle.github.io/graphpipe/#/) [2](https://www.forbes.com/sites/oracle/2018/08/15/open-source-graphpipe-project-hints-at-next-wave-of-ai-expansion/#62a0c8c244ae) ([Tweet]( https://twitter.com/java/status/1038062329794052098))
@@ -133,6 +161,7 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
   - [Disruptive Effects of Cloud Native Machine Learning Systems and Tools](https://www.datascience.com/blog/cloud-native-machine-learning-tools) ([Tweet](https://twitter.com/java/status/1077934809559707650))
 
 ## Misc
+
   - [Introduction to interactive Data Lake Queries](https://blogs.oracle.com/bigdata/interactive-data-lake-queries-at-scale) ([Tweet](https://twitter.com/java/status/989047609259151360))
   - [A Simple Introduction To Data Structures](https://towardsdatascience.com/a-simple-introduction-to-data-structures-part-one-linked-lists-efbb13e9ad33) ([Tweet](https://twitter.com/java/status/883093461842382849))
   - [Videos of various AI/ML related topics by AI Enterprise](https://www.youtube.com/channel/UC1PncmBLZMqlodEt7atfFuw)
@@ -143,10 +172,12 @@ Dataiku DSS: [![Dataiku DSS](https://img.shields.io/docker/pulls/neomatrix369/da
 **See [this link](https://github.com/josephmisiti/awesome-machine-learning#java) for more Java related ML links**
 
 ### Clojure
+
   - [Clojure related ML links](https://github.com/josephmisiti/awesome-machine-learning#clojure)
   - [Scicloj](https://scicloj.github.io/) - an open, free and dynamic hub aimed at advancing doing data science, machine learning and numerical computing in Clojure | [GitHub](https://github.com/scicloj) | [Zulip](https://clojurians.zulipchat.com/#narrow/stream/151924-data-science) | [Twitter](https://twitter.com/scicloj) | [Youtube](http://yt.vu/+scicloj) | [scicloj@gmail.com](mailto:scicloj@gmail.com)
 
 ### Scala
+
   - [Scala related ML links](https://github.com/josephmisiti/awesome-machine-learning#scala)
   - [Scala resources by Chris Albon](https://chrisalbon.com/#scala)
 

--- a/julia-python-and-r.md
+++ b/julia-python-and-r.md
@@ -1,6 +1,21 @@
 # Julia, Python and R
 
+- [General](#general)
+- [Generative Adversarial Network (GAN)](#generative-adversarial-network-gan)
+- [RNN](#rnn)
+- [Natural Language Processing (NLP)](#natural-language-processing-nlp)
+- [Computer Vision](#computer-vision)
+- [Data Science](#data-science)
+- [Machine Learning](#machine-learning)
+  - [Deep Learning](#deep-learning)
+    - [Reinforcement Learning](#reinforcement-learning)
+- [More...](#more)
+- [Contributing](#contributing)
+
+---
+
   ## General
+
    - [Python Toolkit Used for Two Kaggle Top 10% Leaderboard Positions](https://www.reddit.com/r/deeplearning/comments/agx7qr/my_python_toolkit_that_i_used_for_two_kaggle_top/)
    - [Jeff Heaton's Kaggle boosting work](https://github.com/jeffheaton/jh-kaggle-util)
    - [An example on how-to install a Java kernel for JuPyteR notebooks (Graal enabled, where platform supports)](examples/JuPyteR/README.md)
@@ -17,6 +32,7 @@
    - [Book: How to Think Like a Computer Scientist: Interactive Edition](http://interactivepython.org/courselib/static/thinkcspy/index.html) | [How to Think Like a Computer Scientist - non-Interactive Edition](http://openbookproject.net/thinkcs/python/english2e/)
 
   ## Generative Adversarial Network (GAN)
+
    - [A Beginner's Guide to Generative Adversarial Networks (GANs)](https://skymind.ai/wiki/generative-adversarial-network-gan)
    - [A tensorflow implementation of "Deep Convolutional Generative Adversarial Networks"](https://github.com/carpedm20/DCGAN-tensorflow)
    - [Collection of generative models, e.g. GAN, VAE in Pytorch and Tensorflow](https://github.com/wiseodd/generative-models)
@@ -24,45 +40,54 @@
    - [Defense-GAN: Protecting Classifiers Against Adversarial Attacks Using Generative Models](https://arxiv.org/pdf/1805.06605.pdf)
 
   ## Genetic Algorithms
+
   - [Introduction to Genetic Algorithms & their application in data science](https://media.licdn.com/dms/document/C511FAQE99ZtwL7srQA/feedshare-document-pdf-analyzed/0?e=1570906800&v=beta&t=OiKdTPzo2ozpBzVl0N_5JPvzAoqsS2iie9cHNK4BXCg)
 
   ## RNN
+
   - [The Unreasonable Effectiveness of Recurrent Neural Networks - Andrej Karpathy](http://karpathy.github.io/2015/05/21/rnn-effectiveness/)
   
   ## Natural Language Processing (NLP)
+
   - See [Natural Language Processing (NLP)](natural-language-processing/README.md#natural-language-processing-nlp)
 
   ## Computer Vision
+
   ### Motivation
+
   - [What is Computer vision?](https://machinelearningmastery.com/what-is-computer-vision/)
   - [Main topics to be covered (Basic outline)](https://www.pyimagesearch.com/start-here/)
   - [Introduction to CV](https://blog.algorithmia.com/introduction-to-computer-vision)
 
   ### Image Processing
+
   - [Digital Image Processing Basics](https://www.geeksforgeeks.org/digital-image-processing-basics/)
   - [Theory for Image Processing](http://web.ipac.caltech.edu/staff/fmasci/home/astro_refs/Digital_Image_Processing_2ndEd.pdf)
   - [Image and Video Processing course by Duke University, Coursera](https://www.coursera.org/learn/image-processing) (free, paid for certification)
 
   ### OpenCV and tutorials
+
   - [Documentation and examples for each topic](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_table_of_contents_imgproc/py_table_of_contents_imgproc.html)
   
   ### Courses
+
   - [Introduction to Computer Vision, Udacity, GeorgiaTech](https://www.udacity.com/course/introduction-to-computer-vision--ud810) (free, paid for certification)
   - [Stanford Computer Vision Lab : Teaching](http://vision.stanford.edu/teaching.html) - Contains publications other than courses (free)
   - [Introduction to CV, IBM](https://www.coursera.org/learn/introduction-computer-vision-watson-opencv) (free, paid for certification)
   - [Convolutional Neural Networks, Coursera](https://www.coursera.org/learn/convolutional-neural-networks) (free, paid for certification)
   
   ### Conferences to follow
+
   - [CVPR](http://cvpr2019.thecvf.com/)
   - [ICCV](http://iccv2019.thecvf.com/) 
   - [ECCV](https://eccv2020.eu/)
   - [BMVC](https://bmvc2019.org/)
   
   ### Blogs
+
   - [PyImagesearch by Adrian Rosebrock](https://www.pyimagesearch.com/)
   - [Tombone's Computer Vision Blog](http://www.computervisionblog.com/)
   - [Get started in Computer Vision, Quora](https://www.quora.com/q/qqtmowjpnijmeujz/How-to-get-started-in-Computer-Vision-A-guide-for-the-CS-undergrad)
-
 
   ## Data Science
   
@@ -110,7 +135,8 @@
   - See [Cloud/DevOps/Infra > Performance](./cloud-devops-infra/README.md#performance) - to find various ML performance benchmarking suites
   - Also see [Post model-creation analysis, ML interpretation/explainability](./data/README.md#post-model-creation-analysis-ml-interpretationexplainability)
 
-  ## Deep Learning
+  ### Deep Learning
+
    - [FREE! Deep learning book online - by Ian Goodfellow and Yoshua Bengio and Aaron Courville](http://www.deeplearningbook.org/)
    - [A curated list of awesome Deep Learning tutorials, projects and communities](https://github.com/josephmisiti/awesome-deep-learning)
    - [Deep learning library featuring a higher-level API for TensorFlow](https://github.com/tflearn/tflearn)
@@ -126,7 +152,7 @@
    - [Deep learning for 3D printing manufacturing](https://www.youtube.com/watch?v=jAQSM2dhDV4) by [Benjamin Schrauwen](https://www.linkedin.com/in/benjaminschrauwen)
    - [DL topics expanded by Chris Albon](https://chrisalbon.com/#deep_learning) - topics covered: Keras 
   
-  ## Reinforcement Learning
+  #### Reinforcement Learning
 
   - [Reinforcement learning resources curated resources](https://github.com/aikorea/awesome-rl)
   - [Gym: a toolkit for developing and comparing reinforcement learning algorithms](https://github.com/openai/gym)
@@ -150,6 +176,7 @@
   - [Teaching Artificial Agents to Understand Language by Modelling Reward](https://www.researchgate.net/publication/328437364_Teaching_Artificial_Agents_to_Understand_Language_by_Modelling_Reward) by [Edward Grefenstette](https://egrefen.github.io/) | [Video](https://www.youtube.com/watch?v=JCIIeDL9840)
 
 ## More...
+
   - Julia: See [this link](https://github.com/josephmisiti/awesome-machine-learning#julia) for more Julia related ML links
   - Python: See [this link](https://github.com/josephmisiti/awesome-machine-learning#python) for more Python related ML links
   - R: See [this link](https://github.com/josephmisiti/awesome-machine-learning#r) for more R related ML links

--- a/natural-language-processing/README.md
+++ b/natural-language-processing/README.md
@@ -4,8 +4,6 @@ Better NLP: [![Better NLP](https://img.shields.io/docker/pulls/neomatrix369/bett
 
 NLP Java: [![NLP Java](https://img.shields.io/docker/pulls/neomatrix369/nlp-java.svg)](https://hub.docker.com/r/neomatrix369/nlp-java) | NLP Clojure: [![NLP Clojure](https://img.shields.io/docker/pulls/neomatrix369/nlp-clojure.svg)](https://hub.docker.com/r/neomatrix369/nlp-clojure) | NLP Kotlin: [![NLP Kotlin](https://img.shields.io/docker/pulls/neomatrix369/nlp-kotlin.svg)](https://hub.docker.com/r/neomatrix369/nlp-kotlin) | NLP Scala: [![NLP Scala](https://img.shields.io/docker/pulls/neomatrix369/nlp-scala.svg)](https://hub.docker.com/r/neomatrix369/nlp-scala) | NLP using DL4J (cuda): [![NLP using DL4J (cuda)](https://img.shields.io/docker/pulls/neomatrix369/dl4j-nlp-cuda.svg)](https://hub.docker.com/r/neomatrix369/dl4j-nlp-cuda)
 
-## Table of contents
-
 - [General](#general)
 - [Java/JVM](#javajvm)
 - [Courses, Tutorial, Learning resource](#courses-tutorial-learning-resource)
@@ -17,6 +15,7 @@ NLP Java: [![NLP Java](https://img.shields.io/docker/pulls/neomatrix369/nlp-java
 - [Notebooks](#notebooks)
 - [Unstructured to structured data](#unstructured-to-structured-data)
 - [Summarise text](#summarise-text)
+- [Contributing](#contributing)
 
 ---
 

--- a/time-series_anomaly-detection/README.md
+++ b/time-series_anomaly-detection/README.md
@@ -1,5 +1,12 @@
 ## Time-series / anomaly detection
 
+- [Time-series](#timeseries)
+  - [Notebooks](#notebooks)
+  - [Anomaly detection](#anomaly-detection)
+- [Contributing](#contributing)
+
+---
+
 ### Time-series
   - H2O
     - [Driverless AI's time-series support](http://docs.h2o.ai/driverless-ai/latest-stable/docs/userguide/time-series.html)
@@ -17,6 +24,7 @@
   - [A Gentle Introduction to SARIMA for Time Series Forecasting in Python](https://machinelearningmastery.com/sarima-for-time-series-forecasting-in-python/)
 
 #### Notebooks
+
   - [Fuzzy Time series notebook](https://colab.research.google.com/drive/1S1QSZfO3YPVr022nwqJC5bEJvrXbqS_A)
   - [Python Data Science Handbook: Time series notebook](https://github.com/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/03.11-Working-with-Time-Series.ipynb)
 


### PR DESCRIPTION
Following markdown pages have an new/updated ToC:

- README-details.md
- articles-papers-code-data-courses.md
- cloud-devops-infra/README.md
- data/README.md
- java-jvm.md
- julia-python-and-r.md
- natural-language-processing/README.md
- time-series_anomaly-detection/README.md