### PR TITLE
Added DATAQUEST to course list

### DIFF
--- a/courses.md
+++ b/courses.md
@@ -3,6 +3,7 @@
 - [Algorithms](#algorithms)
 - [Cambridge Spark](#cambridge-spark)
 - [Datacamp](#datacamp)
+- [DATAQUEST](https://www.dataquest.io/)
 - [Dataiku](#dataiku)
 - [Data Science](#data-science)
 - [Computer Vision](#computer-vision)


### PR DESCRIPTION
https://www.dataquest.io/ is another excellent resource to learn python.
It offers a Data Science with Python course similar to Datacamp.
One difference is the absence of video lessons or an application for training on smartphones for Dataquest. 
Dataquest offers more courses on mathematics for machine learning that are absent on Datacamp.