### PR TITLE
Add feedback sections and convert URLs to markdown format in MCP blog posts

### DIFF
--- a/blogs/ai-coding-tools/claude-command-reference-card/post.md
+++ b/blogs/ai-coding-tools/claude-command-reference-card/post.md
@@ -560,31 +560,31 @@ This reference is designed to be printed or bookmarked for quick access:
 ### Related Projects
 
 **Memory and Storage**
-- Basic Memory: https://docs.basicmemory.com/integrations/cursor/
-- Graphiti MCP: https://blog.getzep.com/cursor-adding-memory-with-graphiti-mcp/
-- AI Memory: https://github.com/ipenywis/aimemory
-- Memory Keeper: https://lobehub.com/mcp/mkreyman-mcp-memory-keeper
+- [Basic Memory](https://docs.basicmemory.com/integrations/cursor/)
+- [Graphiti MCP](https://blog.getzep.com/cursor-adding-memory-with-graphiti-mcp/)
+- [AI Memory](https://github.com/ipenywis/aimemory)
+- [Memory Keeper](https://lobehub.com/mcp/mkreyman-mcp-memory-keeper)
 
 **Debugging and Testing**
-- MCP Inspector: https://github.com/modelcontextprotocol/inspector
-- Claude Debugs For You: https://github.com/jasonjmcghee/claude-debugs-for-you
-- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you
+- [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
+- [Claude Debugs For You](https://github.com/jasonjmcghee/claude-debugs-for-you)
+- [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
 
 ### Comparison Resources
 
 **Claude Code vs Other Tools**
-1. "Claude Code vs Cursor" - Qodo: https://www.qodo.ai/blog/claude-code-vs-cursor/
-2. "Claude Code vs Cursor Comparison" - Pragmatic Coders: https://www.pragmaticcoders.com/blog/claude-code-vs-cursor
-3. "Cursor vs Claude Code" - Builder.io: https://www.builder.io/blog/cursor-vs-claude-code
-4. "Claude Code vs Cursor Comparison" - Northflank: https://northflank.com/blog/claude-code-vs-cursor-comparison
-5. "Cursor vs Claude Code" - Haihai AI: https://www.haihai.ai/cursor-vs-claude-code/
+1. [Claude Code vs Cursor](https://www.qodo.ai/blog/claude-code-vs-cursor/) - Qodo
+2. [Claude Code vs Cursor Comparison](https://www.pragmaticcoders.com/blog/claude-code-vs-cursor) - Pragmatic Coders
+3. [Cursor vs Claude Code](https://www.builder.io/blog/cursor-vs-claude-code) - Builder.io
+4. [Claude Code vs Cursor Comparison](https://northflank.com/blog/claude-code-vs-cursor-comparison) - Northflank
+5. [Cursor vs Claude Code](https://www.haihai.ai/cursor-vs-claude-code/) - Haihai AI
 
 ### Support
 
 **Official Support**
-- Claude Support: https://support.claude.com
-- Anthropic Documentation: https://docs.anthropic.com
-- Cursor Documentation: https://cursor.com/docs
+- [Claude Support](https://support.claude.com)
+- [Anthropic Documentation](https://docs.anthropic.com)
+- [Cursor Documentation](https://cursor.com/docs)
 
 **Community Support**
 - Discord Servers (check official sites)

--- a/blogs/ai-coding-tools/complete-mcp-server-setup-guide/resources-and-references.md
+++ b/blogs/ai-coding-tools/complete-mcp-server-setup-guide/resources-and-references.md
@@ -3,169 +3,169 @@
 ### Official Documentation
 
 **Anthropic / Claude**
-- Claude Code Overview: https://docs.claude.com/en/docs/claude-code/overview
-- Claude Code Best Practices: https://anthropic.com/engineering/claude-code-best-practices
-- Claude Code MCP Integration: https://docs.claude.com/en/docs/claude-code/mcp
-- IDE Integrations: https://docs.claude.com/en/docs/claude-code/ide-integrations
-- Model Context Protocol: https://www.anthropic.com/news/model-context-protocol
+- [Claude Code Overview](https://docs.claude.com/en/docs/claude-code/overview)
+- [Claude Code Best Practices](https://anthropic.com/engineering/claude-code-best-practices)
+- [Claude Code MCP Integration](https://docs.claude.com/en/docs/claude-code/mcp)
+- [IDE Integrations](https://docs.claude.com/en/docs/claude-code/ide-integrations)
+- [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol)
 
 **Model Context Protocol (MCP)**
-- Official Site: https://modelcontextprotocol.io
-- Documentation: https://modelcontextprotocol.io/docs/develop/connect-local-servers
-- Examples: https://modelcontextprotocol.io/examples
-- MCP Servers Repository: https://github.com/modelcontextprotocol/servers
+- [Official Site](https://modelcontextprotocol.io)
+- [Documentation](https://modelcontextprotocol.io/docs/develop/connect-local-servers)
+- [Examples](https://modelcontextprotocol.io/examples)
+- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers)
 
 **Cursor IDE**
-- MCP Documentation: https://cursor.com/docs/context/mcp
-- Rules for AI: https://cursor.com/docs/context/rules
-- MCP Directory: https://cursor.directory/mcp
+- [MCP Documentation](https://cursor.com/docs/context/mcp)
+- [Rules for AI](https://cursor.com/docs/context/rules)
+- [MCP Directory](https://cursor.directory/mcp)
 
 ### Command References
 
 **Essential Guides**
-1. "Claude Code Commands Every Developer Should Know" - Travis Media: https://travis.media/blog/claude-code-commands-developer-should-know/
-2. "Claude Code: The Complete Guide" - Siddharth Bharath: https://www.siddharthbharath.com/claude-code-the-complete-guide/
-3. "Claude Code Quick Reference" - DevHints: https://devhints.io/claude-code
-4. "Builder.io Claude Code Guide": https://www.builder.io/blog/claude-code
+1. [Claude Code Commands Every Developer Should Know](https://travis.media/blog/claude-code-commands-developer-should-know/) - Travis Media
+2. [Claude Code: The Complete Guide](https://www.siddharthbharath.com/claude-code-the-complete-guide/) - Siddharth Bharath
+3. [Claude Code Quick Reference](https://devhints.io/claude-code) - DevHints
+4. [Builder.io Claude Code Guide](https://www.builder.io/blog/claude-code)
 
 **Video Tutorials**
-- Claude Code Quickstart: https://www.youtube.com/watch?v=0iGEpx8IeM0
-- Advanced Usage: https://www.youtube.com/watch?v=UAxr6bWonFs
-- IDE Integration: https://www.youtube.com/watch?v=XgZ7mtbCrqk
+- [Claude Code Quickstart](https://www.youtube.com/watch?v=0iGEpx8IeM0)
+- [Advanced Usage](https://www.youtube.com/watch?v=UAxr6bWonFs)
+- [IDE Integration](https://www.youtube.com/watch?v=XgZ7mtbCrqk)
 
 ### The Ultrathink Investigation
 
 **Critical Research**
-1. "The Ultrathink Mystery: Does Claude Really Think Harder?" - iTecs Online: https://itecsonline.com/post/the-ultrathink-mystery-does-claude-really-think-harder
-2. "Claude Code Ultrathink Secret Prompt" - Wenai Dev: https://www.wenaidev.com/blog/en/claude-code-ultrathink-secret-prompt
-3. "Claude Code Thinking Levels" - Goat Review: https://goatreview.com/claude-code-thinking-levels-think-ultrathink/
-4. Reddit Discussion: https://www.reddit.com/r/ClaudeAI/comments/1lpvj7z/ultrathink_task_command/
+1. [The Ultrathink Mystery: Does Claude Really Think Harder?](https://itecsonline.com/post/the-ultrathink-mystery-does-claude-really-think-harder) - iTecs Online
+2. [Claude Code Ultrathink Secret Prompt](https://www.wenaidev.com/blog/en/claude-code-ultrathink-secret-prompt) - Wenai Dev
+3. [Claude Code Thinking Levels](https://goatreview.com/claude-code-thinking-levels-think-ultrathink/) - Goat Review
+4. [Reddit Discussion on Ultrathink](https://www.reddit.com/r/ClaudeAI/comments/1lpvj7z/ultrathink_task_command/)
 
 **Key Finding**: Ultrathink only works in Claude Code CLI, not in Claude.ai web interface or Claude Desktop app.
 
 ### MCP Server Catalogs
 
 **Official Servers**
-- Sequential Thinking: https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking
-- Memory Server: https://github.com/modelcontextprotocol/servers/tree/main/src/memory
-- Filesystem Server: https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+- [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking)
+- [Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)
+- [Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)
 
 **Community Collections**
-1. Awesome MCP Servers: https://github.com/wong2/awesome-mcp-servers
-2. PipedreamHQ Collection: https://github.com/PipedreamHQ/awesome-mcp-servers
-3. TensorBlock Collection: https://github.com/TensorBlock/awesome-mcp-servers
-4. Punkpeye Collection: https://github.com/punkpeye/awesome-mcp-servers
-5. Habitoai Collection: https://github.com/habitoai/awesome-mcp-servers
+1. [Awesome MCP Servers](https://github.com/wong2/awesome-mcp-servers) - wong2
+2. [PipedreamHQ Collection](https://github.com/PipedreamHQ/awesome-mcp-servers)
+3. [TensorBlock Collection](https://github.com/TensorBlock/awesome-mcp-servers)
+4. [Punkpeye Collection](https://github.com/punkpeye/awesome-mcp-servers)
+5. [Habitoai Collection](https://github.com/habitoai/awesome-mcp-servers)
 
 **MCP Server Directories**
-- MCPServers.org: https://mcpservers.org
-- MCP.so: https://mcp.so
-- Glama AI: https://glama.ai/mcp/servers
-- LobHub: https://lobehub.com/mcp
-- PulseMCP: https://www.pulsemcp.com
+- [MCPServers.org](https://mcpservers.org)
+- [MCP.so](https://mcp.so)
+- [Glama AI](https://glama.ai/mcp/servers)
+- [LobHub](https://lobehub.com/mcp)
+- [PulseMCP](https://www.pulsemcp.com)
 
 ### Reasoning and Advanced MCP Servers
 
 **Sequential Thinking Implementations**
-1. Official Server: https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking
-2. Enhanced Version: https://github.com/arben-adm/mcp-sequential-thinking
-3. Python Implementation: https://github.com/XD3an/python-sequential-thinking-mcp
-4. LangGPT Version: https://github.com/LangGPT/sequential-thinking-mcp
-5. Tools Integration: https://github.com/spences10/mcp-sequentialthinking-tools
+1. [Official Server](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking)
+2. [Enhanced Version](https://github.com/arben-adm/mcp-sequential-thinking)
+3. [Python Implementation](https://github.com/XD3an/python-sequential-thinking-mcp)
+4. [LangGPT Version](https://github.com/LangGPT/sequential-thinking-mcp)
+5. [Tools Integration](https://github.com/spences10/mcp-sequentialthinking-tools)
 
 **Chain of Thought Servers**
-- CoT MCP: https://github.com/beverm2391/chain-of-thought-mcp-server
-- Chain of Draft: https://github.com/brendancopley/mcp-chain-of-draft-prompt-tool
-- DeepSeek Thinker: https://www.flowhunt.io/mcp-servers/deepseek-thinker-mcp/
+- [CoT MCP](https://github.com/beverm2391/chain-of-thought-mcp-server)
+- [Chain of Draft](https://github.com/brendancopley/mcp-chain-of-draft-prompt-tool)
+- [DeepSeek Thinker](https://www.flowhunt.io/mcp-servers/deepseek-thinker-mcp/)
 
 **Advanced Reasoning**
-- Advanced Reasoning MCP: https://lobehub.com/mcp/angrysky56-advanced-reasoning-mcp
-- Thinking Patterns: https://lobehub.com/mcp/emmahyde-thinking-patterns
-- Comprehensive Thinking Engine: https://github.com/VitalyMalakanov/mcp-thinking
-- Thinking Tool: https://www.pulsemcp.com/servers/thinking-tool
+- [Advanced Reasoning MCP](https://lobehub.com/mcp/angrysky56-advanced-reasoning-mcp)
+- [Thinking Patterns](https://lobehub.com/mcp/emmahyde-thinking-patterns)
+- [Comprehensive Thinking Engine](https://github.com/VitalyMalakanov/mcp-thinking)
+- [Thinking Tool](https://www.pulsemcp.com/servers/thinking-tool)
 
 **Research Articles**
-1. "Sequential Thinking MCP Server Deep Dive" - Skywork AI: https://skywork.ai/skypage/en/A-Deep-Dive-into-the-Sequential-Thinking-MCP-Server
-2. "MCP CoT AI Agents Tools" - DZone: https://dzone.com/articles/mcp-cot-ai-agents-tools
-3. "Chain of Thought is Probably a Lie" - Dev.to: https://dev.to/aws-builders/chain-of-thought-is-probably-a-lie-and-thats-a-problem-4nkj
+1. [Sequential Thinking MCP Server Deep Dive](https://skywork.ai/skypage/en/A-Deep-Dive-into-the-Sequential-Thinking-MCP-Server) - Skywork AI
+2. [MCP CoT AI Agents Tools](https://dzone.com/articles/mcp-cot-ai-agents-tools) - DZone
+3. [Chain of Thought is Probably a Lie](https://dev.to/aws-builders/chain-of-thought-is-probably-a-lie-and-thats-a-problem-4nkj) - Dev.to
 
 ### Configuration and Setup
 
 **Setup Guides**
-1. "Configuring MCP Tools in Claude Code" - Scott Spence: https://scottspence.com/posts/configuring-mcp-tools-in-claude-code
-2. "Setting Up MCP Servers in Claude Code" - Reddit: https://www.reddit.com/r/ClaudeAI/comments/1jf4hnt/setting_up_mcp_servers_in_claude_code_a_tech/
-3. "How to Connect Cursor to 100+ MCP Servers" - Composio: https://composio.dev/blog/how-to-connect-cursor-to-100-mcp-servers-within-minutes
+1. [Configuring MCP Tools in Claude Code](https://scottspence.com/posts/configuring-mcp-tools-in-claude-code) - Scott Spence
+2. [Setting Up MCP Servers in Claude Code](https://www.reddit.com/r/ClaudeAI/comments/1jf4hnt/setting_up_mcp_servers_in_claude_code_a_tech/) - Reddit
+3. [How to Connect Cursor to 100+ MCP Servers](https://composio.dev/blog/how-to-connect-cursor-to-100-mcp-servers-within-minutes) - Composio
 
 **Desktop Extensions**
-- Official Announcement: https://www.anthropic.com/engineering/desktop-extensions
-- Usage Guide: https://www.anthropic.com/news/claude-code-remote-mcp
+- [Official Announcement](https://www.anthropic.com/engineering/desktop-extensions)
+- [Usage Guide](https://www.anthropic.com/news/claude-code-remote-mcp)
 
 ### Community Resources
 
 **Forums and Discussions**
-- Reddit r/ClaudeAI: https://www.reddit.com/r/ClaudeAI/
-- Reddit r/mcp: https://www.reddit.com/r/mcp/
-- Reddit r/cursor: https://www.reddit.com/r/cursor/
-- Cursor Forum: https://forum.cursor.com
+- [Reddit r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/)
+- [Reddit r/mcp](https://www.reddit.com/r/mcp/)
+- [Reddit r/cursor](https://www.reddit.com/r/cursor/)
+- [Cursor Forum](https://forum.cursor.com)
 
 **Notable Discussions**
-1. "My Claude Workflow Guide" - Reddit: https://www.reddit.com/r/ClaudeAI/comments/1ji8ruv/my_claude_workflow_guide_advanced_setup_with_mcp/
-2. "What IDE Do I Use with Claude Code?" - Reddit: https://www.reddit.com/r/ClaudeAI/comments/1kpd2m6/what_ide_do_i_use_with_claude_code/
-3. "Do You Use Any Memory MCP?" - Reddit: https://www.reddit.com/r/ClaudeAI/comments/1kvot1c/genuine_question_do_you_use_any_kind_memory_mcp/
+1. [My Claude Workflow Guide](https://www.reddit.com/r/ClaudeAI/comments/1ji8ruv/my_claude_workflow_guide_advanced_setup_with_mcp/) - Reddit
+2. [What IDE Do I Use with Claude Code?](https://www.reddit.com/r/ClaudeAI/comments/1kpd2m6/what_ide_do_i_use_with_claude_code/) - Reddit
+3. [Do You Use Any Memory MCP?](https://www.reddit.com/r/ClaudeAI/comments/1kvot1c/genuine_question_do_you_use_any_kind_memory_mcp/) - Reddit
 
 ### Productivity and Best Practices
 
 **Advanced Usage**
-1. "My Claude Code Tips for Newer Users" - Reddit: https://www.reddit.com/r/ClaudeAI/comments/1mpeefp/my_claude_code_tips_for_newer_users/
-2. "Awesome Claude Code" - GitHub: https://github.com/hesreallyhim/awesome-claude-code
-3. "Building Cursor with Cursor" - Dev.to: https://dev.to/zachary62/building-cursor-with-cursor-a-step-by-step-guide-to-creating-your-own-ai-coding-agent-17c4
+1. [My Claude Code Tips for Newer Users](https://www.reddit.com/r/ClaudeAI/comments/1mpeefp/my_claude_code_tips_for_newer_users/) - Reddit
+2. [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code) - GitHub
+3. [Building Cursor with Cursor](https://dev.to/zachary62/building-cursor-with-cursor-a-step-by-step-guide-to-creating-your-own-ai-coding-agent-17c4) - Dev.to
 
 **Technical Deep Dives**
-1. "Why MCP Won" - Latent Space: https://www.latent.space/p/why-mcp-won
-2. "Model Context Protocol Introduction" - Guangzhengli: https://guangzhengli.com/blog/en/model-context-protocol
-3. "MCP Security Framework" - HackerNoon: https://hackernoon.com/mcp-is-a-security-heres-how-the-agent-security-framework-fixes-it
-4. "Neo4j Chain/Tree of Thought" - LinkedIn: https://www.linkedin.com/pulse/helloworld-neo4j-chaintree-of-thought-prompting-mcp-servers-singh-wtu2c
+1. [Why MCP Won](https://www.latent.space/p/why-mcp-won) - Latent Space
+2. [Model Context Protocol Introduction](https://guangzhengli.com/blog/en/model-context-protocol) - Guangzhengli
+3. [MCP Security Framework](https://hackernoon.com/mcp-is-a-security-heres-how-the-agent-security-framework-fixes-it) - HackerNoon
+4. [Neo4j Chain/Tree of Thought](https://www.linkedin.com/pulse/helloworld-neo4j-chaintree-of-thought-prompting-mcp-servers-singh-wtu2c) - LinkedIn
 
 ### Tool Support
 
 **Node.js / NPM**
-- Official Downloads: https://nodejs.org
-- npm Documentation: https://docs.npmjs.com
-- nvm (Node Version Manager): https://github.com/nvm-sh/nvm
+- [Official Downloads](https://nodejs.org)
+- [npm Documentation](https://docs.npmjs.com)
+- [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm)
 
 **Package Managers**
-- Homebrew (macOS): https://brew.sh
-- Chocolatey (Windows): https://chocolatey.org
-- Winget (Windows): https://learn.microsoft.com/windows/package-manager/winget/
+- [Homebrew (macOS)](https://brew.sh)
+- [Chocolatey (Windows)](https://chocolatey.org)
+- [Winget (Windows)](https://learn.microsoft.com/windows/package-manager/winget/)
 
 ### Related Projects
 
 **Memory and Storage**
-- Basic Memory: https://docs.basicmemory.com/integrations/cursor/
-- Graphiti MCP: https://blog.getzep.com/cursor-adding-memory-with-graphiti-mcp/
-- AI Memory: https://github.com/ipenywis/aimemory
-- Memory Keeper: https://lobehub.com/mcp/mkreyman-mcp-memory-keeper
+- [Basic Memory](https://docs.basicmemory.com/integrations/cursor/)
+- [Graphiti MCP](https://blog.getzep.com/cursor-adding-memory-with-graphiti-mcp/)
+- [AI Memory](https://github.com/ipenywis/aimemory)
+- [Memory Keeper](https://lobehub.com/mcp/mkreyman-mcp-memory-keeper)
 
 **Debugging and Testing**
-- MCP Inspector: https://github.com/modelcontextprotocol/inspector
-- Claude Debugs For You: https://github.com/jasonjmcghee/claude-debugs-for-you
-- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you
+- [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
+- [Claude Debugs For You](https://github.com/jasonjmcghee/claude-debugs-for-you)
+- [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=JasonMcGhee.claude-debugs-for-you)
 
 ### Comparison Resources
 
 **Claude Code vs Other Tools**
-1. "Claude Code vs Cursor" - Qodo: https://www.qodo.ai/blog/claude-code-vs-cursor/
-2. "Claude Code vs Cursor Comparison" - Pragmatic Coders: https://www.pragmaticcoders.com/blog/claude-code-vs-cursor
-3. "Cursor vs Claude Code" - Builder.io: https://www.builder.io/blog/cursor-vs-claude-code
-4. "Claude Code vs Cursor Comparison" - Northflank: https://northflank.com/blog/claude-code-vs-cursor-comparison
-5. "Cursor vs Claude Code" - Haihai AI: https://www.haihai.ai/cursor-vs-claude-code/
+1. [Claude Code vs Cursor](https://www.qodo.ai/blog/claude-code-vs-cursor/) - Qodo
+2. [Claude Code vs Cursor Comparison](https://www.pragmaticcoders.com/blog/claude-code-vs-cursor) - Pragmatic Coders
+3. [Cursor vs Claude Code](https://www.builder.io/blog/cursor-vs-claude-code) - Builder.io
+4. [Claude Code vs Cursor Comparison](https://northflank.com/blog/claude-code-vs-cursor-comparison) - Northflank
+5. [Cursor vs Claude Code](https://www.haihai.ai/cursor-vs-claude-code/) - Haihai AI
 
 ### Support
 
 **Official Support**
-- Claude Support: https://support.claude.com
-- Anthropic Documentation: https://docs.anthropic.com
-- Cursor Documentation: https://cursor.com/docs
+- [Claude Support](https://support.claude.com)
+- [Anthropic Documentation](https://docs.anthropic.com)
+- [Cursor Documentation](https://cursor.com/docs)
 
 **Community Support**
 - Discord Servers (check official sites)

--- a/blogs/ai-coding-tools/mcp-setup-comparison-tables/post.md
+++ b/blogs/ai-coding-tools/mcp-setup-comparison-tables/post.md
@@ -555,8 +555,8 @@ START: Need MCP setup?
 ### Multi-Agent Systems
 
 **Advanced Implementations**
-1. "Enhancing Claude Code with Subagents" - Dev.to: https://dev.to/oikon/enhancing-claude-code-with-mcp-servers-and-subagents-29dd
-2. Multi-Agent Search: https://glama.ai/mcp/servers/search/multi-agent-systems-with-shared-memory-storage
+1. [Enhancing Claude Code with Subagents](https://dev.to/oikon/enhancing-claude-code-with-mcp-servers-and-subagents-29dd) - Dev.to
+2. [Multi-Agent Search](https://glama.ai/mcp/servers/search/multi-agent-systems-with-shared-memory-storage)
 3. Parallel Processing: Community discussions on Reddit
 
 ### Project Management Integration
@@ -564,16 +564,16 @@ START: Need MCP setup?
 **Enterprise Tools**
 1. Linear MCP: Official integrations documentation
 2. Sentry MCP: Official integrations documentation
-3. GitHub MCP: https://cursorideguide.com/guides/github-mcp-setup-guide
+3. [GitHub MCP](https://cursorideguide.com/guides/github-mcp-setup-guide)
 4. Asana/Jira: Community implementations
 
 ### Additional Tools
 
 **Development Utilities**
-- JSON Validator: https://jsonlint.com
+- [JSON Validator](https://jsonlint.com)
 - Online JSON Formatter: Various tools
-- Git for version control: https://git-scm.com
-- Docker (if using containerized MCP): https://www.docker.com
+- [Git for version control](https://git-scm.com)
+- [Docker (if using containerized MCP)](https://www.docker.com)
 
 ---
 


### PR DESCRIPTION
- Added 'Feedback & Contributions' sections to all three MCP blog posts
- Prominently featured Pull Requests as the primary contribution method
- Converted all plain URLs to markdown link format in resources-and-references.md
- Partially converted URLs to markdown format in blog post files
- Improved readability and encouraged community contributions