### PR TITLE
docs(ai-coding-tools): standardize Windows paths, fix Cursor labels, add Claude Code monitoring usage

### DIFF
--- a/blogs/ai-coding-tools/complete-mcp-server-setup-guide/claude-code-setup.md
+++ b/blogs/ai-coding-tools/complete-mcp-server-setup-guide/claude-code-setup.md
@@ -37,7 +37,7 @@ claude --version
 |----|-------------|
 | **macOS** | `~/.claude.json` |
 | **Linux** | `~/.claude.json` |
-| **Windows** | `%APPDATA%\.claude.json` |
+| **Windows** | `%USERPROFILE%\.claude.json` |
 
 -OR-
 

--- a/blogs/ai-coding-tools/complete-mcp-server-setup-guide/cursor-ide-setup.md
+++ b/blogs/ai-coding-tools/complete-mcp-server-setup-guide/cursor-ide-setup.md
@@ -32,7 +32,7 @@ Cursor is a modern AI-first IDE built on VS Code, offering a full development en
 **Global Config** (affects all projects):
 - Accessed via Cursor Settings → MCP
 - Stored in Cursor's global settings
-- File: `~/.cursor/mcp.json` (macOs/Linux) | `%USERPROFILE%\.cursor\mcp.json` (Windows)
+- File: `~/.cursor/mcp.json` (macOS/Linux) | `%USERPROFILE%\.cursor\mcp.json` (Windows)
 
 ---
 

--- a/blogs/ai-coding-tools/complete-mcp-server-setup-guide/post.md
+++ b/blogs/ai-coding-tools/complete-mcp-server-setup-guide/post.md
@@ -31,7 +31,7 @@ Before we dive into setup, understand what you're installing:
 |------|----------|-----------|-----------------|
 | **Claude Desktop** | GUI workflows, exploring projects | Desktop app | `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) |
 | **Claude Code** | Terminal workflows, CI/CD, scripting | CLI | `~/.claude.json` |
-| **Cursor IDE** | Full IDE experience, VS Code users | Desktop IDE | `~/.cursor/mcp.json` global settings |
+| **Cursor IDE** | Full IDE experience, VS Code users | Desktop IDE | `~/.cursor/mcp.json` (global settings) |
 
 **Architecture**
 


### PR DESCRIPTION
- Standardize to %USERPROFILE% for Windows config paths
- Fix macOS casing and Cursor label to (global settings)
- Add claude-monitor and ccusage with screenshots in Claude Code guide
- Keep stdio requirement messaging consistent across docs