### PR TITLE
docs: Add README.md files for missing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Awesome Artificial Intelligence, Machine Learning and Deep Learning as we learn 
 ### Reference Materials
 - [Cheatsheets](./reference/cheatsheets.md#cheatsheets)
 - [Articles, papers, code, data, courses](./reference/articles-papers-code-data-courses.md#articles-papers-code-data-courses)
-- [Research Papers](./papers/google-x/README.md) - Curated Google & X-Team research papers
+- [Research Papers](./papers/README.md) - Curated research papers and academic resources
 - [Presentations](./presentations/README.md) - Slide decks and talk links
 - [Models](README-details.md#models)
 - [Notebooks](./notebooks/README.md#notebooks)

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,20 +25,20 @@ Practical code examples and implementations demonstrating AI/ML/DL concepts, fra
 
 ### Data & Infrastructure
 
-- **[Data Examples](./data/)** - Data processing, databases, and feature engineering examples
+- **[Data Examples](./data/README.md)** - Data processing, databases, and feature engineering examples
   - Graph databases (Grakn)
   - Dataiku DSS
   - Feature importance filtering
 
 ### Cloud & Deployment
 
-- **[Cloud DevOps Infra](./cloud-devops-infra/)** - Cloud deployment examples
+- **[Cloud DevOps Infra](./cloud-devops-infra/README.md)** - Cloud deployment examples
   - Valohai (MLPMnist, NLP-CUDA)
   - Weights & Biases integration
 
 ### Python
 
-- **[Python Examples](./python/)** - Python framework examples
+- **[Python Examples](./python/README.md)** - Python framework examples
   - Streamlit applications
 
 ## Related

--- a/examples/cloud-devops-infra/README.md
+++ b/examples/cloud-devops-infra/README.md
@@ -1,0 +1,40 @@
+# ☁️ Cloud & DevOps Examples
+
+> Examples and implementations for cloud deployment, MLOps, and DevOps in AI/ML/DL.
+
+[Home](../../README.md) · [☁️ Infrastructure](../../infrastructure/README.md) · [📓 Notebooks](../../notebooks/README.md) · [🧰 Tools](../../tools/README.md) · [📊 Data](../../data/README.md)
+
+## At a glance
+
+Practical examples demonstrating cloud deployment, MLOps workflows, and DevOps practices for AI/ML/DL applications.
+
+## Examples by Platform
+
+### MLOps Platforms
+
+- **[Valohai](./valohai/)** - Valohai MLOps platform examples
+  - MLPMnist model deployment
+  - NLP-CUDA implementations
+  - ML pipeline orchestration
+
+### Experiment Tracking
+
+- **[Weights & Biases](./wandb/)** - Weights & Biases integration examples
+  - Feature importance tracking
+  - Competition submissions
+  - Experiment monitoring
+
+## Related
+
+- [Infrastructure](../../infrastructure/README.md) - Cloud and infrastructure resources
+- [MLOps & Deployment](../../domains/mlops-deployment/README.md) - MLOps domain guide
+- [Examples](../README.md) - All examples index
+- [Tools](../../tools/README.md) - DevOps and deployment tools
+
+# Contributing
+
+Contributions are very welcome! Please share cloud deployment and MLOps examples with the community.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#cloud--devops-examples) · [← Back to examples](../README.md) · [← Back home](../../README.md)

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -1,0 +1,45 @@
+# 📊 Data Examples
+
+> Examples and implementations for data processing, databases, feature engineering, and data analysis.
+
+[Home](../../README.md) · [📓 Notebooks](../../notebooks/README.md) · [📊 Data](../../data/README.md) · [🧰 Tools](../../tools/README.md) · [🧠 NLP](../../natural-language-processing/README.md)
+
+## At a glance
+
+Practical examples demonstrating data processing workflows, database integrations, and feature engineering techniques.
+
+## Examples by Category
+
+### Databases
+
+- **[Graph Databases](./databases/graph/grakn/README.md)** - Grakn graph database examples
+  - Graph queries and data modeling
+  - Performance benchmarks
+  - Docker containerization
+  - Graql query examples and tutorials
+
+### Data Platforms
+
+- **[Dataiku DSS](./dataiku/README.md)** - Dataiku Data Science Studio examples
+  - Docker setup and deployment
+  - Platform integration examples
+
+### Feature Engineering
+
+- **[Feature Importance Filtering](./feature-importance-filtering/)** - Feature importance analysis examples
+  - Python implementations for feature selection
+
+## Related
+
+- [Data](../data/README.md) - Main data resources and guides
+- [Examples](../README.md) - All examples index
+- [Notebooks](../../notebooks/README.md) - Data analysis notebooks
+- [Tools](../../tools/README.md) - Data processing tools
+
+# Contributing
+
+Contributions are very welcome! Please share data processing examples and database integration implementations.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#data-examples) · [← Back to examples](../README.md) · [← Back home](../../README.md)

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,33 @@
+# 🐍 Python Examples
+
+> Python code examples, implementations, and demonstrations for AI/ML/DL.
+
+[Home](../../README.md) · [🐍 Python](../../python/README.md) · [📓 Notebooks](../../notebooks/README.md) · [🧰 Tools](../../tools/README.md) · [📊 Data](../../data/README.md)
+
+## At a glance
+
+Python examples demonstrating frameworks, libraries, and best practices for AI/ML/DL development.
+
+## Examples by Framework
+
+### Web Frameworks
+
+- **[Streamlit](./frameworks/streamlit/README.md)** - Streamlit application examples
+  - Interactive ML applications
+  - Data visualization dashboards
+  - Model deployment interfaces
+
+## Related
+
+- [Python Guide](../../python/README.md) - Comprehensive Python guide for AI/ML/DL
+- [Examples](../README.md) - All examples index
+- [Notebooks](../../notebooks/README.md) - Python notebooks
+- [Tools](../../tools/README.md) - Python tools and libraries
+
+# Contributing
+
+Contributions are very welcome! Please share Python examples that demonstrate AI/ML/DL concepts and best practices.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#python-examples) · [← Back to examples](../README.md) · [← Back home](../../README.md)

--- a/papers/README.md
+++ b/papers/README.md
@@ -1,0 +1,34 @@
+# 📄 Research Papers
+
+> Curated collection of research papers, articles, and academic resources in AI/ML/DL.
+
+[Home](../README.md) · [📓 Notebooks](../notebooks/README.md) · [🧰 Tools](../tools/README.md) · [📊 Data](../data/README.md) · [🧠 NLP](../natural-language-processing/README.md)
+
+## At a glance
+
+Research papers and academic resources from leading organizations and researchers in AI, machine learning, and deep learning.
+
+## Paper Collections
+
+### Google & X-Team
+
+- **[Google & X-Team Papers](./google-x/README.md)** - Curated research papers from Google and Google X (X-Team)
+  - Tensor Networks for Machine Learning
+  - Deep Network Generalization
+  - Robotics and Simulation
+  - And more...
+
+## Related
+
+- [Research Papers](../README.md#reference-materials) - Referenced in main README
+- [Articles & Papers](../reference/articles-papers-code-data-courses.md) - More papers and articles
+- [Notebooks](../notebooks/README.md) - Related notebook implementations
+- [Examples](../examples/README.md) - Code examples related to papers
+
+# Contributing
+
+Contributions are very welcome! Share research papers and academic resources with the community.
+
+Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../LICENSE.md) policy.
+
+[↑ Back to top](#research-papers) · [← Back home](../README.md)

--- a/presentations/README.md
+++ b/presentations/README.md
@@ -17,9 +17,9 @@ Use this index to explore project overviews, workshops, and community talks with
 - [Data](../data/README.md)
 - [NLP](../natural-language-processing/README.md)
 
-- On AI/ML/DL related topics, see [awesome-ai-ml-dl](awesome-ai-ml-dl)
-- On Data related topics, see [data](data)
-- On NLP related topics, see [nlp](nlp)
+- On AI/ML/DL related topics, see [awesome-ai-ml-dl](./awesome-ai-ml-dl/README.md)
+- On Data related topics, see [data](./data/README.md)
+- On NLP related topics, see [nlp](./nlp/README.md)
 - Better NLP: [First presentation: launch of Better NLP](../examples/better-nlp/presentations/09-Mar-2019/Better-NLP-Presentation-Slides.pdf) | [Follow-up presentation of Better NLP](../examples/better-nlp/presentations/29-Jun-2019/Better-NLP-2.0-one-library-rules-them-all-Presentation-Slides.pdf)
 - NLP Profiler: [Demo](https://github.com/neomatrix369/nlp_profiler/#demo) | [First presentation: Abhishek Talks](https://youtu.be/sdPOyqMfK7M?t=2274) | [Follow-up presentation: NLP Zurich](https://github.com/neomatrix369/nlp_profiler/tree/master/presentations/01-nlp-zurich-2020)
 

--- a/presentations/awesome-ai-ml-dl/README.md
+++ b/presentations/awesome-ai-ml-dl/README.md
@@ -1,0 +1,35 @@
+# 🎤 Awesome AI-ML-DL Presentations
+
+> Project overviews, workshops, and talks about the Awesome AI-ML-DL repository and related topics.
+
+[Home](../../README.md) · [🖥️ Presentations](../README.md) · [📓 Notebooks](../../notebooks/README.md) · [📊 Data](../../data/README.md) · [🧰 Tools](../../tools/README.md)
+
+## At a glance
+
+Presentations and talks showcasing the Awesome AI-ML-DL repository, its contents, and related AI/ML/DL topics.
+
+## Presentations
+
+### Conferences & Workshops
+
+- **[01 - JOnConf 2020](./01-jonconf-2020/README.md)** - Java developer conference talk
+- **[02 - Abhishek Talks 2020](./02-abhishektalks-2020/README.md)** - Community presentation
+- **[03 - MakeItWeek 2020](./03-makeitweek-2020/README.md)** - Tribuo introduction
+- **[04 - GBA APAC Tour 2020](./04-gba-apac-tour-2020/README.md)** - Workshop presentation
+- **[05 - AI Enterprise Virtual User Group 2021](./05-ai-enterprise-virtual-user-group-2021/README.md)** - Enterprise AI talk
+- **[06 - The Out-of-the-Box Developer 2022](./06-the-out-of-the-box-developer-2022/README.md)** - Developer tools and practices
+
+## Related
+
+- [Presentations](../README.md) - All presentations index
+- [Home](../../README.md) - Main repository page
+- [Contributing](../../CONTRIBUTING.md) - How to contribute
+- [Notebooks](../../notebooks/README.md) - Related notebooks
+
+# Contributing
+
+Contributions are very welcome! Share presentations about the repository or related AI/ML/DL topics.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#awesome-ai-ml-dl-presentations) · [← Back to presentations](../README.md) · [← Back home](../../README.md)

--- a/presentations/data/README.md
+++ b/presentations/data/README.md
@@ -1,0 +1,39 @@
+# 📊 Data Presentations
+
+> Slide decks and presentations on data science, data analysis, and data engineering topics.
+
+[Home](../../README.md) · [📊 Data](../../data/README.md) · [🖥️ Presentations](../README.md) · [📓 Notebooks](../../notebooks/README.md) · [🧰 Tools](../../tools/README.md)
+
+## At a glance
+
+Presentations covering data analysis, cleaning, visualization, explainable AI, and data engineering best practices.
+
+## Presentations
+
+### Meetups & Conferences
+
+- **[01 - MAM ML Study Group Meetup](./01-mam-ml-study-group-meetup/)** - Introduction to Data Analysis and Cleaning
+- **[02 - Devoxx UK 2019](./02-devoxx-uk-2019/README.md)** - Do we know our data, as good as we know our tools?
+- **[03 - Meetup UK 2019](./03-meetup-uk-2019/)** - Towards Explainable AI
+- **[04 - Grakn Cosmos 2020](./04-grakn-cosmos-2020/README.md)** - Graph databases and data modeling
+- **[05 - Kaggle Days Delhi NCR 2022](./05-kaggle-days-delhi-ncr-2022/README.md)** - Studying the limitations of statistical measurements
+
+### Reference Materials
+
+- **Data Visualization Guide** - How to Pick the Right Chart Type
+- **Trackener Example** - Physics functions usage example
+
+## Related
+
+- [Data Resources](../../data/README.md) - Data science guides and resources
+- [Presentations](../README.md) - All presentations index
+- [Notebooks](../../notebooks/README.md) - Data analysis notebooks
+- [Examples](../../examples/data/README.md) - Data processing examples
+
+# Contributing
+
+Contributions are very welcome! Share your data science presentations and slide decks with the community.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#data-presentations) · [← Back to presentations](../README.md) · [← Back home](../../README.md)

--- a/presentations/nlp/README.md
+++ b/presentations/nlp/README.md
@@ -1,0 +1,30 @@
+# 🧠 NLP Presentations
+
+> Natural Language Processing presentations and slide decks.
+
+[Home](../../README.md) · [🧠 NLP](../../natural-language-processing/README.md) · [🖥️ Presentations](../README.md) · [📓 Notebooks](../../notebooks/README.md) · [🧰 Tools](../../tools/README.md)
+
+## At a glance
+
+Presentations covering Natural Language Processing topics, techniques, and applications.
+
+## Presentations
+
+### Research & Techniques
+
+- **[Natural Language Processing - MaM](./Natural_Language_Processing_-_MaM.pdf)** - NLP fundamentals and techniques
+
+## Related
+
+- [NLP Resources](../../natural-language-processing/README.md) - Comprehensive NLP guide
+- [Presentations](../README.md) - All presentations index
+- [Notebooks](../../notebooks/nlp/README.md) - NLP notebooks
+- [Examples](../../examples/better-nlp/README.md) - NLP code examples
+
+# Contributing
+
+Contributions are very welcome! Share NLP presentations and slide decks with the community.
+
+Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also have a read about our [licensing](../../LICENSE.md) policy.
+
+[↑ Back to top](#nlp-presentations) · [← Back to presentations](../README.md) · [← Back home](../../README.md)


### PR DESCRIPTION
- Created 7 high-priority README.md files:
  - papers/README.md - Root-level index for research papers
  - examples/data/README.md - Data examples index
  - examples/python/README.md - Python examples index
  - examples/cloud-devops-infra/README.md - Cloud & DevOps examples index
  - presentations/data/README.md - Data presentations index
  - presentations/awesome-ai-ml-dl/README.md - Project presentations index
  - presentations/nlp/README.md - NLP presentations index

- Updated parent README links:
  - README.md: Updated papers link to use new index
  - examples/README.md: Updated links to data/, python/, cloud-devops-infra/
  - presentations/README.md: Updated links to data/, awesome-ai-ml-dl/, nlp/

All high-priority documentation directories now have proper index pages with navigation.