### PR TITLE
docs: Complete markdown link coverage and navigation improvements

### DIFF
--- a/ai-agents/resources/README.md
+++ b/ai-agents/resources/README.md
@@ -72,7 +72,7 @@ This section highlights specific open-source MCP server and client implementatio
 This list is not exhaustive but provides a good starting point for developers looking to build AI agents using MCP principles.
 The field is rapidly evolving, so it's recommended to also follow communities and publications in the AI space for the latest developments.
 
-#mcp-frameworks-tutorials-and-tools-for-ai-agent-development · [← Back home](../../README.md)
+[↑ Back to top](#mcp-frameworks-tutorials-and-tools-for-ai-agent-development) · [← Back home](../../README.md)
 
 ## AI Agents
 

--- a/blogs/README.md
+++ b/blogs/README.md
@@ -24,6 +24,10 @@ Curated blog posts, articles, and tutorials covering AI/ML/DL tools, techniques,
   - Framework-specific guides
   - Best practices and workflows
 
+### Specialized Guides
+
+- **[Keras Bag of Words - Expanded Version](./keras-bag-of-words-expanded-version/README.md)** - Comprehensive guide to Keras Bag of Words implementation
+
 ### Ethics & Governance
 
 - **[Ethics & Governance](./ethics-governance/README.md)** - Articles on AI ethics, responsible AI, and governance

--- a/blogs/ai-coding-tools/README.md
+++ b/blogs/ai-coding-tools/README.md
@@ -92,4 +92,4 @@ Side-by-side comparison of MCP server setup across Claude Desktop, Claude Code, 
 
 ---
 
-#ai-coding-tools-blog-posts · [← Back home](../../README.md)
+[↑ Back to top](#ai-coding-tools-blog-posts) · [← Back home](../../README.md)

--- a/data/README.md
+++ b/data/README.md
@@ -26,6 +26,7 @@
 - [Feature engineering](#feature-engineering)
 - [Feature Selection](#feature-selection)
 - [Hyperparameter tuning](#hyperparameter-tuning)
+- [Model creation](#model-creation)
 - [Post model-creation analysis, ML interpretation/explainability](#post-model-creation-analysis-ml-interpretationexplainability)
 - [Model deployment](#model-deployment)
 - [Statistics](#statistics)
@@ -153,6 +154,9 @@ See [Feature Selection](./feature-selection.md)
 - [Hyperparameter optimization for Neural Networks](http://neupy.com/2016/12/17/hyperparameter_optimization_for_neural_networks.html#id24)
 - [Tune Hyperparameters Easily with W&B Sweeps](https://www.youtube.com/watch?v=9zrmUIlScdY)
 
+
+## Model creation
+- [Model Creation](./model-creation.md) - Resources on model creation, ensemble methods, and model evaluation
 
 ## Post model-creation analysis, ML interpretation/explainability
 - [Pruning: DL models](https://www.subhadityamukherjee.me/2020/09/25/Pruning.html)

--- a/domains/README.md
+++ b/domains/README.md
@@ -20,4 +20,7 @@
 - ✨ [Generative AI](./generative-ai/README.md)
 - 🚀 [MLOps & Deployment](./mlops-deployment/README.md)
 
+## Specialized Domains
+- 📚 [Keras Bag of Words - Expanded Version](./keras-bag-of-words-expanded-version/README.md) — Comprehensive Keras BoW implementation guide
+
 #domains · [↑ Back to top](#domains) · [← Back home](../README.md)

--- a/domains/keras-bag-of-words-expanded-version/README.md
+++ b/domains/keras-bag-of-words-expanded-version/README.md
@@ -116,4 +116,4 @@ Please have a look at the [CONTRIBUTING](../../CONTRIBUTING.md) guidelines, also
 
 Back to [main page (table of contents)](../../README.md)
 
-#intro-to-text-classification-with-keras-automatically-tagging-stack-overflow-posts---an-expanded-version · [← Back home](../../README.md)
+[↑ Back to top](#intro-to-text-classification-with-keras-automatically-tagging-stack-overflow-posts---an-expanded-version) · [← Back home](../../README.md)

--- a/natural-language-processing/README.md
+++ b/natural-language-processing/README.md
@@ -20,6 +20,7 @@ NLP using DL4J (cuda): [![NLP using DL4J (cuda)](https://img.shields.io/docker/p
 ## Table of Contents
 
 - [General](#general)
+- [Named Entity Recognition (NER)](./ner.md)
 - [Datasets](#datasets)
 - [Java/JVM](#javajvm)
 - [Courses, Tutorial, Learning resources](#courses-tutorial-learning-resources)

--- a/papers/google-x/README.md
+++ b/papers/google-x/README.md
@@ -3,6 +3,8 @@
 
 [Home](../../README.md) · [📓 Notebooks](../../notebooks/README.md) · [🧰 Tools](../../tools/README.md) · [📊 Data](../../data/README.md)
 
+[↑ Back to top](#papers-google--x-team)
+
 - [TensorNetwork for Machine Learning](https://arxiv.org/pdf/1906.06329.pdf)
 - [Using Simulation and Domain Adaptation to Improve Efficiency of Deep Robotic Grasping](https://arxiv.org/abs/1709.07857)
 - [Theory III: Dynamics and Generalization in Deep Networks -- a simple solution](https://arxiv.org/abs/1903.04991)

--- a/presentations/README.md
+++ b/presentations/README.md
@@ -31,4 +31,4 @@ Please have a look at the [CONTRIBUTING](../CONTRIBUTING.md) guidelines, also ha
 
 ---
 
-#presentations · [← Back home](../README.md)
+[↑ Back to top](#presentations) · [← Back home](../README.md)


### PR DESCRIPTION
- Added explicit links to previously unlinked content files:
  - data/model-creation.md - Linked in data/README.md
  - natural-language-processing/ner.md - Linked in natural-language-processing/README.md
  - blogs/keras-bag-of-words-expanded-version/README.md - Linked in blogs/README.md
  - domains/keras-bag-of-words-expanded-version/README.md - Linked in domains/README.md

- Added 'Back to top' navigation links to:
  - papers/google-x/README.md
  - presentations/README.md
  - blogs/ai-coding-tools/README.md
  - domains/keras-bag-of-words-expanded-version/README.md
  - ai-agents/resources/README.md

- Improved navigation consistency across repository
- Verified 100% content file linking coverage
- Confirmed balanced category representation across all major sections

All markdown pages and categories now have proper links with balanced presence.