### PR TITLE
Add AI Job Displacement Tracker dataset

### DIFF
--- a/data/datasets.md
+++ b/data/datasets.md
@@ -25,6 +25,7 @@
 
 ## Clean / ready-to-use datasets
 
+- [AI Job Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured, source-backed dataset tracking 96 AI-attributed workforce reductions (457K workers affected, 13 countries, 13 sectors). Every entry includes source URLs, attribution tier, and job functions. Available in JSON and CSV.
 - [Boston Housing Dataset (archive contains clean dataset)](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/tag/v0.1) | [Download](https://github.com/neomatrix369/awesome-ai-ml-dl/releases/download/v0.1/boston_housing_dataset.zip)
 - Google Dataset Search:
   - https://toolbox.google.com/datasetsearch


### PR DESCRIPTION
## Summary

Adds the [AI Job Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the **Datasets** page under **Clean / ready-to-use datasets**.

This is a structured, source-backed dataset tracking 96 AI-attributed workforce reductions (457K workers affected across 13 countries and 13 sectors). Every entry includes source URLs, attribution tier, and affected job functions. The data is available in JSON and CSV formats under CC-BY-4.0.

The dataset is relevant to the AI/ML community as it provides structured data on the real-world workforce impact of AI adoption — useful for research, analysis, and policy discussions.

## Changes

- Added one entry to `data/datasets.md` in the "Clean / ready-to-use datasets" section, following the existing `[Resource](Link) - Description` format and alphabetical ordering.