### PR TITLE
Add Toprank to Tools & Frameworks

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -46,6 +46,7 @@ A comprehensive guide to tools, technologies, and platforms used in artificial i
 
 ### IDEs and Editors
 - [VS Code](https://code.visualstudio.com/) - Popular code editor with AI extensions
+- [Toprank](https://github.com/nowork-studio/toprank) - Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills; connects Google Search Console, PageSpeed Insights, and the Google Ads API to ship fixes like meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes
 - [PyCharm](https://www.jetbrains.com/pycharm/) - Python IDE with ML support
 - [Spyder](https://www.spyder-ide.org/) - Scientific Python development environment
 - [RStudio](https://rstudio.com/) - R development environment


### PR DESCRIPTION
## Summary
- add Toprank to `tools/README.md` under `Development Environments > IDEs and Editors`
- include the canonical source link and a concise description of its Claude Code SEO and Google Ads workflow
- use this section as the closest existing fit because the repository does not have a `Developer Productivity Tools` category

## Why Toprank fits
Toprank is an open-source MIT Claude Code plugin with 181 GitHub stars and active maintenance as of 2026-04-09. It adds 9 SEO and Google Ads skills for developer workflows and connects Google Search Console, PageSpeed Insights, and the Google Ads API. The project can help ship practical fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.

## File updated
- `tools/README.md` in the `### IDEs and Editors` section