### PR TITLE
Add AI Dev Jobs, Not Human Search, and 8bitconcepts

### DIFF
--- a/papers/README.md
+++ b/papers/README.md
@@ -18,6 +18,13 @@ Research papers and academic resources from leading organizations and researcher
   - Robotics and Simulation
   - And more...
 
+### Enterprise AI & Governance
+
+- **[8bitconcepts Research Papers](https://8bitconcepts.com)** - 11 research papers on frontier AI architectures, enterprise AI governance, and applied ML systems
+  - Enterprise AI Governance
+  - Frontier Architecture Analysis
+  - Applied ML Systems Design
+
 ## Related
 
 - [Research Papers](../README.md#reference-materials) - Referenced in main README

--- a/tools/README.md
+++ b/tools/README.md
@@ -183,4 +183,6 @@ Contributions are very welcome! Please see our [Contributing Guidelines](../CONT
 
 ## Tools & Frameworks
 
+- [AI Dev Jobs](https://aidevboard.com) - AI/ML job board with REST API and MCP server for searching 5,300+ jobs across ML engineering, data science, and AI research roles
 - [FastAPI](https://fastapi.tiangolo.com/) - Python web framework
+- [Not Human Search](https://nothumansearch.ai) - Search engine for AI agent tools and APIs with agentic readiness scores for 1,400+ services, plus an MCP server for programmatic discovery


### PR DESCRIPTION
## Summary

Adds three resources across Tools and Papers:

**Tools (tools/README.md):**
- **AI Dev Jobs** (https://aidevboard.com) - AI/ML job board with REST API and MCP server for searching 5,300+ jobs across ML engineering, data science, and AI research roles.
- **Not Human Search** (https://nothumansearch.ai) - Search engine for AI agent tools and APIs with agentic readiness scores for 1,400+ services, plus an MCP server for programmatic discovery.

**Papers (papers/README.md):**
- **8bitconcepts** (https://8bitconcepts.com) - 11 research papers on frontier AI architectures, enterprise AI governance, and applied ML systems design.

All entries are sorted alphabetically per CONTRIBUTING.md guidelines. Each has clear descriptions distinguishing them from existing entries.

## Links

- AI Dev Jobs: https://aidevboard.com | [GitHub](https://github.com/unitedideas/aidevboard-mcp)
- Not Human Search: https://nothumansearch.ai | [GitHub](https://github.com/unitedideas/nothumansearch)
- 8bitconcepts: https://8bitconcepts.com