### PR TITLE
Add grugbot420 to AI Agents Tools and Frameworks

### DIFF
--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -107,6 +107,7 @@ Several tools and frameworks have emerged to simplify the development of AI agen
 *   **Langsmith:** A platform by Langchain for debugging, testing, evaluating, and monitoring LLM applications. It provides visibility into agent behavior and helps in identifying areas for improvement.
 *   **Google A2A (Agents for Automation):** While specific public details might vary, Google has research and products focused on AI agents for automating tasks and processes.
 *   **Google GenAI (Generative AI):** Google offers a suite of Generative AI tools and models (e.g., Gemini) that can be the core "Model" component of AI agents, providing powerful language understanding and generation capabilities. This includes Vertex AI for building and deploying AI models.
+*   **[grugbot420](https://github.com/grug-group420/grugbot420):** A neuromorphic cognitive engine in Julia for multi-model AI orchestration. Deploys domain-expert AI specimens through architectural configuration rather than traditional training. MIT licensed.
 *   **Other tools:** Many other specialized tools exist for aspects like vector databases (e.g., Pinecone, Weaviate) for semantic search, workflow orchestration (e.g., Apache Airflow with AI plugins), and more.
 
 ## Examples


### PR DESCRIPTION
## grugbot420

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia for multi-model AI orchestration. It deploys domain-expert AI specimens through architectural configuration rather than traditional training.

Adding to the Tools and Frameworks for Building AI Agents section.

- License: MIT
- Language: Julia
- Source: https://github.com/grug-group420/grugbot420